### PR TITLE
s/scratch bitmap/output bitmap/ to fix broken link

### DIFF
--- a/css-paint-api/Overview.bs
+++ b/css-paint-api/Overview.bs
@@ -24,7 +24,7 @@ urlPrefix: https://heycam.github.io/webidl/; type: dfn;
         url: throw; text: thrown
 urlPrefix: https://html.spec.whatwg.org/multipage/scripting.html; type: dfn;
     text: reset the rendering context to its default state
-    text: scratch bitmap
+    text: output bitmap
     text: set bitmap dimensions
     url: concept-canvas-alpha; text: alpha
 urlPrefix: http://www.ecma-international.org/ecma-262/6.0/#sec-; type: dfn;
@@ -258,11 +258,11 @@ Note: The {{PaintRenderingContext2D}} implements a subset of the {{CanvasRenderi
     Specifically it doesn't implement the {{CanvasHitRegion}}, {{CanvasImageData}},
     {{CanvasUserInterface}}, {{CanvasText}} or {{CanvasTextDrawingStyles}} APIs.
 
-A {{PaintRenderingContext2D}} object has a <a>scratch bitmap</a>. This is initialised when the
-object is created. The size of the <a>scratch bitmap</a> is the size of the fragment it is
+A {{PaintRenderingContext2D}} object has a <a>output bitmap</a>. This is initialised when the
+object is created. The size of the <a>output bitmap</a> is the size of the fragment it is
 rendering.
 
-The size of the <a>scratch bitmap</a> does not necessarily represent the size of the actual bitmap
+The size of the <a>output bitmap</a> does not necessarily represent the size of the actual bitmap
 that the user agent will use internally or during rendering. For example, if the visual viewport is
 zoomed the user agent may internally use bitmaps which correspond to the number of device pixels in
 the coordinate space, so that the resulting rendering is of high quality.
@@ -271,19 +271,19 @@ The {{PaintRenderingContext2D}} object should have its <a>alpha</a> flag set to 
 rendering context is initially fully transparent.
 
 Additionally the user agent may record the sequence of drawing operations which have been applied to
-the <a>scratch bitmap</a> such that the user agent can subsequently draw onto a device bitmap at the
-correct resolution. This also allows user agents to re-use the same output of the <a>scratch
+the <a>output bitmap</a> such that the user agent can subsequently draw onto a device bitmap at the
+correct resolution. This also allows user agents to re-use the same output of the <a>output
 bitmap</a> repeatably while the visual viewport is being zoomed for example.
 
 When the user agent is to <dfn>create a PaintRenderingContext2D object</dfn> for a given |width|,
 |height| it <em>must</em> run the following steps:
     1. Create a new {{PaintRenderingContext2D}}.
-    2. <a>Set bitmap dimensions</a> for the context's <a>scratch bitmap</a> to |width| and |height|.
+    2. <a>Set bitmap dimensions</a> for the context's <a>output bitmap</a> to |width| and |height|.
     3. Return the new {{PaintRenderingContext2D}}.
 
 Note: The initial state of the rendering context is set inside the <a>set bitmap dimensions</a>
     algorithm, as it invokes <a>reset the rendering context to its default state</a> and clears the
-    <a>scratch bitmap</a>.
+    <a>output bitmap</a>.
 
 Drawing an image {#drawing-an-image}
 ====================================


### PR DESCRIPTION
The spec uses the term "scratch bitmap", which links to
 https://html.spec.whatwg.org/multipage/scripting.html#scratch-bitmap
which is a broken link.

I believe this is meant to point to the definition of "output bitmap" in that HTML spec, i.e. it should be pointing to:
 https://html.spec.whatwg.org/multipage/scripting.html#output-bitmap
...and it should be using the consistent term (with the word "output" instead of "scratch").

Not sure if the HTML spec changed out from under us or what, but anyway, this should get us back to a state with working links.