### PR TITLE
Fix register/unregisterProperty on CSS interface to be static.

### DIFF
--- a/css-properties-values-api/Overview.bs
+++ b/css-properties-values-api/Overview.bs
@@ -68,8 +68,8 @@ dictionary PropertyDescriptor {
 };
 
 partial interface CSS {
-  void registerProperty(PropertyDescriptor descriptor);
-  void unregisterProperty(DOMString name);
+  static void registerProperty(PropertyDescriptor descriptor);
+  static void unregisterProperty(DOMString name);
 };
 </pre>
 


### PR DESCRIPTION
Tiny pull request to make register/unregisterProperty functions on the CSS interface to be static.
See @tabatkins' comment and the discussion at [1].

[1]: https://github.com/w3c/css-houdini-drafts/issues/216#issuecomment-224766248