### PR TITLE
[css-typed-om] Make CSSSkew and CSSRotation store their angle members as CSSAngleValues instead of doubles

### DIFF
--- a/css-typed-om/Overview.bs
+++ b/css-typed-om/Overview.bs
@@ -467,7 +467,7 @@ interface CSSRotation : CSSTransformComponent {
 	readonly attribute double x;
 	readonly attribute double y;
 	readonly attribute double z;
-	readonly attribute double angle;
+	readonly attribute CSSAngleValue angle;
 };
 
 [Constructor(double x, double y),
@@ -481,8 +481,8 @@ interface CSSScale : CSSTransformComponent {
 [Constructor(double dx, double dy),
  Constructor(CSSAngleValue ax, CSSAngleValue ay)]
 interface CSSSkew : CSSTransformComponent {
-	readonly attribute double ax;
-	readonly attribute double ay;
+	readonly attribute CSSAngleValue ax;
+	readonly attribute CSSAngleValue ay;
 };
 
 [Constructor(CSSLengthValue length)]


### PR DESCRIPTION
This makes them more consistent with CSSPerspective and CSSTranslation, which store their length members and CSSLengthValues.