### PR TITLE
[css-typed-om] Remove skew/rotate double constructors, and change angle member type

### DIFF
--- a/css-typed-om/Overview.bs
+++ b/css-typed-om/Overview.bs
@@ -478,7 +478,8 @@ interface CSSScale : CSSTransformComponent {
 	readonly attribute double z;
 };
 
-[Constructor(double ax, double ay)]
+[Constructor(double dx, double dy),
+ Constructor(CSSAngleValue ax, CSSAngleValue ay)]
 interface CSSSkew : CSSTransformComponent {
 	readonly attribute double ax;
 	readonly attribute double ay;
@@ -518,13 +519,20 @@ and y &amp; z values of 0 could be:
 </div>
 
 When a {{CSSRotation}} is constructed with a double (as opposed to a
-{{CSSAngleValue}}), the angle is taken to be in degrees.
+{{CSSAngleValue}}), the angle is taken to be in degrees. Likewise, when
+{{CSSSkew}} is constructed with doubles, both arguments are taken to be angles
+in degrees.
 
 <div class=note>
 The following two CSSRotations are equivalent:
 <pre class='lang-javascript'>
 		CSSRotation(angle);
 		CSSRotation(CSSAngleValue(angle, "deg"));
+</pre>
+Likewise, the following two CSSSkews are equivalent:
+<pre class='lang-javascript'>
+    CSSSkew(ax, ay);
+    CSSSkew(CSSAngleValue(ax, "deg"), CSSAngleValue(ay, "deg"));
 </pre>
 </div>
 

--- a/css-typed-om/Overview.bs
+++ b/css-typed-om/Overview.bs
@@ -459,15 +459,13 @@ interface CSSTranslation : CSSTransformComponent {
 	readonly attribute CSSLengthValue z;
 };
 
-[Constructor(double degrees),
- Constructor(CSSAngleValue angle),
- Constructor(double x, double y, double z, double degrees),
+[Constructor(CSSAngleValue angle),
  Constructor(double x, double y, double z, CSSAngleValue angle)]
 interface CSSRotation : CSSTransformComponent {
 	readonly attribute double x;
 	readonly attribute double y;
 	readonly attribute double z;
-	readonly attribute double angle;
+	readonly attribute CSSAngleValue angle;
 };
 
 [Constructor(double x, double y),
@@ -478,11 +476,10 @@ interface CSSScale : CSSTransformComponent {
 	readonly attribute double z;
 };
 
-[Constructor(double dx, double dy),
- Constructor(CSSAngleValue ax, CSSAngleValue ay)]
+[Constructor(CSSAngleValue ax, CSSAngleValue ay)]
 interface CSSSkew : CSSTransformComponent {
-	readonly attribute double ax;
-	readonly attribute double ay;
+	readonly attribute CSSAngleValue ax;
+	readonly attribute CSSAngleValue ay;
 };
 
 [Constructor(CSSLengthValue length)]
@@ -516,24 +513,6 @@ and y &amp; z values of 0 could be:
 *   translateX(10px)
 *   translate3d(10px, 0, 0)
 
-</div>
-
-When a {{CSSRotation}} is constructed with a double (as opposed to a
-{{CSSAngleValue}}), the angle is taken to be in degrees. Likewise, when
-{{CSSSkew}} is constructed with doubles, both arguments are taken to be angles
-in degrees.
-
-<div class=note>
-The following two CSSRotations are equivalent:
-<pre class='lang-javascript'>
-		CSSRotation(angle);
-		CSSRotation(CSSAngleValue(angle, "deg"));
-</pre>
-Likewise, the following two CSSSkews are equivalent:
-<pre class='lang-javascript'>
-    CSSSkew(ax, ay);
-    CSSSkew(CSSAngleValue(ax, "deg"), CSSAngleValue(ay, "deg"));
-</pre>
 </div>
 
 When a {{CSSTransformValue}} is read from a {{StylePropertyMap}}, each


### PR DESCRIPTION
As discussed in https://github.com/w3c/css-houdini-drafts/issues/272