### PR TITLE
[css-typed-om] Remove double constructors for CSSRotation and CSSSkew

### DIFF
--- a/css-typed-om/Overview.bs
+++ b/css-typed-om/Overview.bs
@@ -464,9 +464,7 @@ interface CSSTranslation : CSSTransformComponent {
 	readonly attribute CSSLengthValue z;
 };
 
-[Constructor(double degrees),
- Constructor(CSSAngleValue angle),
- Constructor(double x, double y, double z, double degrees),
+[Constructor(CSSAngleValue angle),
  Constructor(double x, double y, double z, CSSAngleValue angle)]
 interface CSSRotation : CSSTransformComponent {
 	readonly attribute double x;
@@ -483,8 +481,7 @@ interface CSSScale : CSSTransformComponent {
 	readonly attribute double z;
 };
 
-[Constructor(double dx, double dy),
- Constructor(CSSAngleValue ax, CSSAngleValue ay)]
+[Constructor(CSSAngleValue ax, CSSAngleValue ay)]
 interface CSSSkew : CSSTransformComponent {
 	readonly attribute CSSAngleValue ax;
 	readonly attribute CSSAngleValue ay;
@@ -521,24 +518,6 @@ and y &amp; z values of 0 could be:
 *   translateX(10px)
 *   translate3d(10px, 0, 0)
 
-</div>
-
-When a {{CSSRotation}} is constructed with a double (as opposed to a
-{{CSSAngleValue}}), the angle is taken to be in degrees. Likewise, when
-{{CSSSkew}} is constructed with doubles, both arguments are taken to be angles
-in degrees.
-
-<div class=note>
-The following two CSSRotations are equivalent:
-<pre class='lang-javascript'>
-		CSSRotation(angle);
-		CSSRotation(CSSAngleValue(angle, "deg"));
-</pre>
-Likewise, the following two CSSSkews are equivalent:
-<pre class='lang-javascript'>
-    CSSSkew(ax, ay);
-    CSSSkew(CSSAngleValue(ax, "deg"), CSSAngleValue(ay, "deg"));
-</pre>
 </div>
 
 When a {{CSSTransformValue}} is read from a {{StylePropertyMap}}, each


### PR DESCRIPTION
As discussed in #272