### PR TITLE
[css-typed-om] Rename CSSFontFaceValue.fontFaceName to fontFamilyName

### DIFF
--- a/css-typed-om/Overview.bs
+++ b/css-typed-om/Overview.bs
@@ -721,9 +721,9 @@ objects, the {{CSSURLImageValue/url}} attribute contains the URL that references
 
 <pre class='idl'>
 
-[Constructor(DOMString fontFaceName)]
+[Constructor(DOMString fontFamilyName)]
 interface CSSFontFaceValue : CSSResourceValue {
-	readonly attribute DOMString fontFaceName;
+	readonly attribute DOMString fontFamilyName;
 };
 
 </pre>


### PR DESCRIPTION
Fixes https://github.com/w3c/css-houdini-drafts/issues/322
