### PR TITLE
[worklets] Multiple fixes to the {{Worklet/import()}} algorithm.

### DIFF
--- a/worklets/Overview.bs
+++ b/worklets/Overview.bs
@@ -40,7 +40,7 @@ urlPrefix: https://html.spec.whatwg.org/multipage/webappapis.html; type: dfn;
     text: environment settings object
     text: event loop
     text: event loop processing model
-    text: fetch a module script tree
+    url: #fetch-a-module-worker-script-tree; text: fetch a module worker script graph
     text: global object
     text: https state
     text: incumbent settings object
@@ -61,6 +61,12 @@ urlPrefix: https://html.spec.whatwg.org/multipage/infrastructure.html; type: dfn
     urlPrefix: #js-;
         text: syntaxerror;
     url: resolve-a-url; text: resolve;
+urlPrefix: https://infra.spec.whatwg.org/#; type: dfn;
+    text: list
+    urlPrefix: list-
+        text: append
+        text: is empty
+        text: remove
 urlPrefix: https://www.w3.org/2001/tag/doc/promises-guide; type: dfn;
     text: a new promise
 urlPrefix: http://www.ecma-international.org/ecma-262/6.0/#sec-; type: dfn;
@@ -147,7 +153,12 @@ interface WorkletGlobalScope {
 };
 </pre>
 
-A {{WorkletGlobalScope}} has an associated <a>environment settings object</a>.
+Each {{WorkletGlobalScope}} has an associated <a>environment settings object</a>.
+
+Each {{WorkletGlobalScope}} has a <dfn>worklet global scope execution environment</dfn>. This
+execution environment may be parallel (i.e. it may be on a separate thread, process, or other
+equivalent construct), or it may live on the same thread or process as the {{Worklet}} object it
+belongs to. Which thread or process it lives on is decided by the user-agent.
 
 Note:
     The {{WorkletGlobalScope}} has a limited global scope when compared to a
@@ -158,21 +169,25 @@ Note:
 ### The event loop ### {#the-event-loop}
 
 Each {{WorkletGlobalScope}} object has a distinct <a>event loop</a>. This <a>event loop</a> has no
-associated <a>browsing context</a>, and only its <a>microtask queue</a> is used (all other <a>task
-queues</a> are not used). The <a>event loop</a> is created by the <a>create a
+associated <a>browsing context</a>. Only tasks associated with the author invoking
+{{Worklet/import()}} use the <a>event loop</a>, in addition to the <a>microtask queue</a> when the
+user-agent invokes callbacks. The <a>event loop</a> is created by the <a>create a
 WorkletGlobalScope</a> algorithm.
+
+The <a>event loop</a> is run on the <a>worklet global scope execution environment</a> defined above.
 
 Note:
     Even through the <a>event loop processing model</a> specifies that it loops continually,
-    practically implementations aren't expected to do this. The <a>microtask queue</a> is the only
-    queue used and is emptied while <a>invoking callback functions</a> provided by the author.
+    practically implementations aren't expected to do this. The <a>microtask queue</a> is emptied
+    while <a>invoking callback functions</a> provided by the author.
 
 ### Creating a WorkletGlobalScope ### {#creating-a-workletglobalscope}
 
-When a user agent is to <dfn>create a WorkletGlobalScope</dfn>, for a given |worklet|, it
-<em>must</em> run the following steps:
+When a user agent is to <dfn>create a WorkletGlobalScope</dfn>, given |workletGlobalScopeType|,
+|moduleResponsesMap|, and |outsideSettings| it <em>must</em> run the following steps:
 
-    1. Let |workletGlobalScopeType| be the |worklet|'s <a>worklet global scope type</a>.
+    1. Create the <a>worklet global scope execution environment</a> and run the rest of these steps
+        in that context.
 
     2. Call the JavaScript <a>InitializeHostDefinedRealm</a> abstract operation with the following
         customizations:
@@ -184,24 +199,27 @@ When a user agent is to <dfn>create a WorkletGlobalScope</dfn>, for a given |wor
 
         - Do not obtain any source texts for scripts or modules.
 
-    3. Let |settingsObject| be the result of <a>set up a worklet environment settings object</a>
+    3. Let |insideSettings| be the result of <a>set up a worklet environment settings object</a>
         with |realmExecutionContext|.
 
-    4. Associate the |settingsObject| with |workletGlobalScope|.
+    4. Associate the |insideSettings| with |workletGlobalScope|.
 
-    5. For each |entry| in the given |worklet|'s <a>module responses map</a> (in insertion order),
-        run the following substeps:
+    5. For each |entry| in the given |moduleResponsesMap| (in insertion order), run the following
+        substeps:
 
         1. Let |resolvedModuleURL| be |entry|'s key.
 
-        2. Let |script| be the result of <a>fetch a module script tree</a> given
-            |resolvedModuleURL|, "anonymous" for the <a>CORS setting attribute</a>, and
-            |settingsObject|.
-
-        Note: Worklets follow <a>web workers</a> here in not allowing "use-credentials" for
-            fetching resources.
+        2. Let |script| be the result of <a>fetch a worklet script</a> given |resolvedModuleURL|,
+            |moduleResponsesMap|, |outsideSettings|, and |insideSettings|.
 
         3. <a>Run a module script</a> given |script|.
+
+        Note: <a>Fetch a worklet script</a> won't actually perform a network request as it will hit
+            the worklet's <a>module responses map</a>. It also won't have a parsing error as at this
+            point it should have successfully been parsed by another worklet global scope. I.e.
+            |script| should never be <em>null</em> here.
+
+    6. Run the <a>responsible event loop</a> specified by |insideSettings|.
 
 ### Script settings for worklets ### {#script-settings-for-worklets}
 
@@ -285,85 +303,130 @@ The <a>module responses map</a> exists to ensure that {{WorkletGlobalScope}}s cr
 times contain the same set of script source text and have the same behaviour. The creation of
 additional {{WorkletGlobalScope}}s should be transparent to the author.
 
-Note:
+<div class='note'>
     Practically user-agents aren't expected to implement the following algorithm using a
-    thread-safe map. Instead when {{Worklet/import}} is called user-agents can fetch the module
+    thread-safe map. Instead when {{Worklet/import()}} is called user-agents can fetch the module
     graph on the main thread, and send the fetched sources (the data contained in the <a>module
     responses map</a>) to each thread which has a {{WorkletGlobalScope}}.
 
     If the user agent wishes to create a new {{WorkletGlobalScope}} it can simply sent the list of
     all fetched sources from the main thread to the thread which owns the {{WorkletGlobalScope}}.
+</div>
 
 When the <dfn method for=Worklet>import(|moduleURL|)</dfn> method is called on a {{Worklet}} object,
 the user agent <em>must</em> run the following steps:
     1. Let |promise| be <a>a new promise</a>.
 
-    2. Let |resolvedModuleURL| be the result of <a>parsing</a> the |moduleURL| argument relative to
+    2. Let |worklet| be the current {{Worklet}}.
+
+    3. Let |resolvedModuleURL| be the result of <a>parsing</a> the |moduleURL| argument relative to
         the <a>relevant settings object</a> of <b>this</b>.
 
-    3. If this fails, reject |promise| with a "<a>SyntaxError</a>" <a>DOMException</a> and abort
+    4. If this fails, reject |promise| with a "<a>SyntaxError</a>" <a>DOMException</a> and abort
         these steps.
 
-    4. Ensure that there is at least one {{WorkletGlobalScope}} in the <a>worklet's
-        WorkletGlobalScopes</a>. If not <a>create a WorkletGlobalScope</a> given the current
-        {{Worklet}}.
+    5. Return |promise|, and then continue running this algorithm <a>in parallel</a>.
+
+    6. Let |outsideSettings| be the <a>relevant settings object</a> of <b>this</b>.
+
+    7. Let |moduleResponsesMap| be |worklet|'s <a>module responses map</a>.
+
+    8. Let |workletGlobalScopeType| be |worklet|'s <a>worklet global scope type</a>.
+
+    9. Ensure that there is at least one {{WorkletGlobalScope}} in the <a>worklet's
+        WorkletGlobalScopes</a>.
+
+        If not run the following substeps:
+
+            1. <a>Create a WorkletGlobalScope</a> given |workletGlobalScopeType|,
+                |moduleResponsesMap|, and |outsideSettings|.
+
+            2. Add the {{WorkletGlobalScope}} to <a>worklet's WorkletGlobalScopes</a>.
 
         The user-agent may also create additional {{WorkletGlobalScope}}s at this time.
 
-    5. Let |outsideSettings| be the <a>relevant settings object</a> of <b>this</b>.
+        Asynchronously wait for this step to complete before continuing.
 
-    6. Run the following steps <a>in parallel</a>:
+    10. Let |pendingTaskList| be a new <a>list</a>.
 
-        1. For each {{WorkletGlobalScope}} in the <a>worklet's WorkletGlobalScopes</a>, run these
-            substeps:
+    11. For each |workletGlobalScope| in the <a>worklet's WorkletGlobalScopes</a>, run these
+        substeps:
 
-            1. Let |insideSettings| be the {{WorkletGlobalScope}}'s associated <a>environment
-                settings object</a>.
+        1. <a>Append</a> |workletGlobalScope| to |pendingTaskList|.
 
-            2. <a>Fetch a module script tree</a> given |resolvedModuleURL|, "omit", the empty string
-                (as no cryptographic nonce is present for worklets), "not parser-inserted",
-                "script", |outsideSettings|, and |insideSettings|.
+        2. <a>Queue a task</a> on the |workletGlobalScope| to <a>fetch and invoke a worklet
+            script</a> given |workletGlobalScope|, |resolvedModuleURL|, |moduleResponsesMap|,
+            |outsideSettings|, |pendingTaskList|, and |promise|.
 
-                To <a>perform the request</a> given |request|, perform the following steps:
+    Note: The rejecting and resolving of the |promise| occurs within the <a>fetch and invoke a
+        worklet script</a> algorithm.
 
-                    1. Let |cache| be the current {{Worklet}}'s <a>module responses map</a>.
+<br>
 
-                    2. Let |url| be |request|'s <a >url</a>.
+When the user-agent is to <dfn>fetch and invoke a worklet script</dfn> given |workletGlobalScope|,
+|resolvedModuleURL|, |moduleResponsesMap|, |outsideSettings|, |pendingTaskList| and |promise| the
+user-agent <em>must</em> run the following steps:
 
-                    3. If |cache| contains an entry with key |url| whose value is "fetching", wait
-                        (<a>in parallel</a>) until that entry's value changes, then proceed to the
-                        next step.
+Note: This algorithm should be run within the <a>worklet global scope execution environment</a>.
 
-                    4. If |cache| contains an entry with key |url|, asynchronously complete this
-                        algorithm with that entry's value, and abort these steps.
+1. Let |insideSettings| be the |workletGlobalScope|'s associated <a>environment settings object</a>.
 
-                    5. Create an entry in |cache| with key |url| and value "fetching".
+2. Let |script| by the result of <a>fetch a worklet script</a> given |resolvedModuleURL|,
+    |moduleResponsesMap|, |outsideSettings|, and |insideSettings|.
 
-                    6. <a>Fetch</a> |request|.
+3. If |script| is <em>null</em> <a>queue a task</a> on |outsideSettings|'s <a>responsible event
+    loop</a> to run the following substeps:
 
-                    7. Let |response| be the result of <a>fetch</a> when it asynchronously
-                        completes.
+    1. <a>Remove</a> |workletGlobalScope| from |pendingTaskList|.
 
-                    8. Set the value of the entry in |cache| whose key is |url| to |response|, and
-                        asynchronously complete this algorithm with |response|.
+    2. Reject |promise| with an "<a>AbortError</a>" <a>DOMException</a>.
 
-            3. Let |script| be the result of <a>fetch a module script tree</a> when it
-                asynchronously completes.
+4. <a>Run a module script</a> given |script|.
 
-                If |script| is <em>null</em> reject |promise| with a "<a>AbortError</a>"
-                <a>DOMException</a> and abort all these steps.
+5. <a>Queue a task</a> on |outsideSettings|'s <a>responsible event loop</a> to run the following
+    substeps:
 
-            4. <a>Run a module script</a> given |script|.
+    1. <a>Remove</a> |workletGlobalScope| from |pendingTaskList|.
 
-        2. If <em>all</em> the steps above succeeded (in particular, if all of the scripts parsed
-                and loaded into the global scopes), resolve |promise|.
-                <br>Otherwise, reject |promise|.
+    2. If |pendingTaskList| <a>is empty</a> then resolve |promise|.
 
-        Note: Specifically, if a script fails to parse or fails to load over the network, it will
-            reject the promise; if the script throws an error while first evaluating the promise
-            should resolve as a classes may have been registered correctly.
+<br>
 
-    7. Return |promise|.
+When the user-agent is to <dfn>fetch a worklet script</dfn> given |resolvedModuleURL|,
+|moduleResponsesMap|, |outsideSettings|, and |insideSettings| the user-agent <em>must</em>
+run the following steps:
+
+Note: This algorithm should be run within the <a>worklet global scope execution environment</a>.
+
+1. <a>Fetch a module worker script graph</a> given |resolvedModuleURL|, |outsideSettings|, "script",
+    "omit", and |insideSettings|.
+
+    To <a>perform the request</a> given |request|, perform the following steps:
+
+        1. Let |cache| be the |moduleResponsesMap|.
+
+        2. Let |url| be |request|'s <a >url</a>.
+
+        3. If |cache| contains an entry with key |url| whose value is "fetching", wait (<a>in
+            parallel</a>) until that entry's value changes, then proceed to the next step.
+
+        4. If |cache| contains an entry with key |url|, asynchronously complete this algorithm with
+            that entry's value, and abort these steps.
+
+        5. Create an entry in |cache| with key |url| and value "fetching".
+
+        6. <a>Fetch</a> |request|.
+
+        7. Let |response| be the result of <a>fetch</a> when it asynchronously completes.
+
+        8. Set the value of the entry in |cache| whose key is |url| to |response|, and
+            asynchronously complete this algorithm with |response|.
+
+2. Return the result of <a>fetch a module worker script graph</a> when it asynchronously completes.
+
+Note: Specifically, if a script fails to parse or fails to load over the network, it will reject the
+    promise. If the script throws an error while first evaluating the promise should resolve as a
+    classes may have been registered correctly.
 
 <div class=example>
     When an author imports code into a {{Worklet}} the code may run against multiple

--- a/worklets/Overview.bs
+++ b/worklets/Overview.bs
@@ -347,12 +347,10 @@ the user agent <em>must</em> run the following steps:
         for=pending-tasks-struct>counter</a> initialized to the length of <a>worklet's
         WorkletGlobalScopes</a>.
 
-    11. For each |workletGlobalScope| in the <a>worklet's WorkletGlobalScopes</a>, run the following
-        substep:
-
-        1. <a>Queue a task</a> on the |workletGlobalScope| to <a>fetch and invoke a worklet
-            script</a> given |workletGlobalScope|, |moduleURLRecord|, |moduleResponsesMap|,
-            |outsideSettings|, |pendingTaskStruct|, and |promise|.
+    11. For each |workletGlobalScope| in the <a>worklet's WorkletGlobalScopes</a>, <a>queue a
+        task</a> on the |workletGlobalScope| to <a>fetch and invoke a worklet script</a> given
+        |workletGlobalScope|, |moduleURLRecord|, |moduleResponsesMap|, |outsideSettings|,
+        |pendingTaskStruct|, and |promise|.
 
     Note: The rejecting and resolving of the |promise| occurs within the <a>fetch and invoke a
         worklet script</a> algorithm.

--- a/worklets/Overview.bs
+++ b/worklets/Overview.bs
@@ -307,7 +307,7 @@ additional {{WorkletGlobalScope}}s should be transparent to the author.
 </div>
 
 A <dfn>pending tasks struct</dfn> is a <a>struct</a> consiting of:
-    - A <dfn for=pending-tasks-struct>counter</dfn>.
+    - A <dfn for="pending tasks struct">counter</dfn>.
 This is used by the algorithms below.
 
 <hr>
@@ -344,7 +344,7 @@ the user agent <em>must</em> run the following steps:
         Wait for this step to complete before continuing.
 
     10. Let |pendingTaskStruct| be a new <a>pending tasks struct</a> with <a
-        for=pending-tasks-struct>counter</a> initialized to the length of <a>worklet's
+        for="pending tasks struct">counter</a> initialized to the length of <a>worklet's
         WorkletGlobalScopes</a>.
 
     11. For each |workletGlobalScope| in the <a>worklet's WorkletGlobalScopes</a>, <a>queue a
@@ -371,10 +371,10 @@ Note: This algorithm is to be run within the <a>worklet global scope execution e
 3. If |script| is <em>null</em>, then <a>queue a task</a> on |outsideSettings|'s <a>responsible
     event loop</a> to run these steps:
 
-    1. If |pendingTaskStruct|'s <a for=pending-tasks-struct>counter</a> is not <b>-1</b>, then
+    1. If |pendingTaskStruct|'s <a for="pending tasks struct">counter</a> is not <b>-1</b>, then
         run these steps:
 
-        1. Set |pendingTaskStruct|'s <a for=pending-tasks-struct>counter</a> to <b>-1</b>.
+        1. Set |pendingTaskStruct|'s <a for="pending tasks struct">counter</a> to <b>-1</b>.
 
         2. Reject |promise| with an "<a>AbortError</a>" <a>DOMException</a>.
 
@@ -382,12 +382,12 @@ Note: This algorithm is to be run within the <a>worklet global scope execution e
 
 5. <a>Queue a task</a> on |outsideSettings|'s <a>responsible event loop</a> to run these steps:
 
-    1. If |pendingTaskStruct|'s <a for=pending-tasks-struct>counter</a> is not <b>-1</b>, then run
+    1. If |pendingTaskStruct|'s <a for="pending tasks struct">counter</a> is not <b>-1</b>, then run
         these steps:
 
-        1. Decrement |pendingTaskStruct|'s <a for=pending-tasks-struct>counter</a> by <b>1</b>.
+        1. Decrement |pendingTaskStruct|'s <a for="pending tasks struct">counter</a> by <b>1</b>.
 
-        1. If |pendingTaskStruct|'s <a for=pending-tasks-struct>counter</a> is <b>0</b>, then
+        1. If |pendingTaskStruct|'s <a for="pending tasks struct">counter</a> is <b>0</b>, then
             resolve |promise|.
 
 <hr>

--- a/worklets/Overview.bs
+++ b/worklets/Overview.bs
@@ -10,10 +10,6 @@ Abstract:  This specification defines an API for running scripts in stages of th
 Editor: Ian Kilpatrick, ikilpatrick@chromium.org
 </pre>
 
-<pre class="link-defaults">
-spec:infra; type:dfn; text:list
-</pre>
-
 <pre class="anchors">
 urlPrefix: http://heycam.github.io/webidl/; type: dfn;
     text: AbortError
@@ -310,6 +306,12 @@ additional {{WorkletGlobalScope}}s should be transparent to the author.
     all fetched sources from the main thread to the thread which owns the {{WorkletGlobalScope}}.
 </div>
 
+A <dfn>pending tasks struct</dfn> is a <a>struct</a> consiting of:
+    - A <dfn for=pending-tasks-struct>counter</dfn>.
+This is used by the algorithms below.
+
+<hr>
+
 When the <dfn method for=Worklet>import(|moduleURL|)</dfn> method is called on a {{Worklet}} object,
 the user agent <em>must</em> run the following steps:
     1. Let |promise| be <a>a new promise</a>.
@@ -341,16 +343,16 @@ the user agent <em>must</em> run the following steps:
 
         Wait for this step to complete before continuing.
 
-    10. Let |pendingTaskList| be a new <a>list</a>.
+    10. Let |pendingTaskStruct| be a new <a>pending tasks struct</a> with <a
+        for=pending-tasks-struct>counter</a> initialized to the length of <a>worklet's
+        WorkletGlobalScopes</a>.
 
-    11. For each |workletGlobalScope| in the <a>worklet's WorkletGlobalScopes</a>, run these
-        substeps:
+    11. For each |workletGlobalScope| in the <a>worklet's WorkletGlobalScopes</a>, run the following
+        substep:
 
-        1. <a for=list>Append</a> |workletGlobalScope| to |pendingTaskList|.
-
-        2. <a>Queue a task</a> on the |workletGlobalScope| to <a>fetch and invoke a worklet
+        1. <a>Queue a task</a> on the |workletGlobalScope| to <a>fetch and invoke a worklet
             script</a> given |workletGlobalScope|, |moduleURLRecord|, |moduleResponsesMap|,
-            |outsideSettings|, |pendingTaskList|, and |promise|.
+            |outsideSettings|, |pendingTaskStruct|, and |promise|.
 
     Note: The rejecting and resolving of the |promise| occurs within the <a>fetch and invoke a
         worklet script</a> algorithm.
@@ -358,7 +360,7 @@ the user agent <em>must</em> run the following steps:
 <hr>
 
 When the user agent is to <dfn>fetch and invoke a worklet script</dfn> given |workletGlobalScope|,
-|moduleURLRecord|, |moduleResponsesMap|, |outsideSettings|, |pendingTaskList|, and |promise|, the
+|moduleURLRecord|, |moduleResponsesMap|, |outsideSettings|, |pendingTaskStruct|, and |promise|, the
 user agent <em>must</em> run the following steps:
 
 Note: This algorithm is to be run within the <a>worklet global scope execution environment</a>.
@@ -371,17 +373,24 @@ Note: This algorithm is to be run within the <a>worklet global scope execution e
 3. If |script| is <em>null</em>, then <a>queue a task</a> on |outsideSettings|'s <a>responsible
     event loop</a> to run these steps:
 
-    1. <a for=list>Remove</a> |workletGlobalScope| from |pendingTaskList|.
+    1. If |pendingTaskStruct|'s <a for=pending-tasks-struct>counter</a> is not <b>-1</b>, then
+        run these steps:
 
-    2. Reject |promise| with an "<a>AbortError</a>" <a>DOMException</a>.
+        1. Set |pendingTaskStruct|'s <a for=pending-tasks-struct>counter</a> to <b>-1</b>.
+
+        2. Reject |promise| with an "<a>AbortError</a>" <a>DOMException</a>.
 
 4. <a>Run a module script</a> given |script|.
 
 5. <a>Queue a task</a> on |outsideSettings|'s <a>responsible event loop</a> to run these steps:
 
-    1. <a for=list>Remove</a> |workletGlobalScope| from |pendingTaskList|.
+    1. If |pendingTaskStruct|'s <a for=pending-tasks-struct>counter</a> is not <b>-1</b>, then run
+        these steps:
 
-    2. If |pendingTaskList| <a for=list>is empty</a>, then resolve |promise|.
+        1. Decrement |pendingTaskStruct|'s <a for=pending-tasks-struct>counter</a> by <b>1</b>.
+
+        1. If |pendingTaskStruct|'s <a for=pending-tasks-struct>counter</a> is <b>0</b>, then
+            resolve |promise|.
 
 <hr>
 

--- a/worklets/Overview.bs
+++ b/worklets/Overview.bs
@@ -10,6 +10,10 @@ Abstract:  This specification defines an API for running scripts in stages of th
 Editor: Ian Kilpatrick, ikilpatrick@chromium.org
 </pre>
 
+<pre class="link-defaults">
+spec:infra; type:dfn; text:list
+</pre>
+
 <pre class="anchors">
 urlPrefix: http://heycam.github.io/webidl/; type: dfn;
     text: AbortError
@@ -40,7 +44,6 @@ urlPrefix: https://html.spec.whatwg.org/multipage/webappapis.html; type: dfn;
     text: environment settings object
     text: event loop
     text: event loop processing model
-    url: #fetch-a-module-worker-script-tree; text: fetch a module worker script graph
     text: global object
     text: https state
     text: incumbent settings object
@@ -58,15 +61,7 @@ urlPrefix: https://html.spec.whatwg.org/multipage/webappapis.html; type: dfn;
 urlPrefix: https://html.spec.whatwg.org/multipage/infrastructure.html; type: dfn;
     text: cors setting attribute
     text: in parallel
-    urlPrefix: #js-;
-        text: syntaxerror;
     url: resolve-a-url; text: resolve;
-urlPrefix: https://infra.spec.whatwg.org/#; type: dfn;
-    text: list
-    urlPrefix: list-
-        text: append
-        text: is empty
-        text: remove
 urlPrefix: https://www.w3.org/2001/tag/doc/promises-guide; type: dfn;
     text: a new promise
 urlPrefix: http://www.ecma-international.org/ecma-262/6.0/#sec-; type: dfn;
@@ -158,7 +153,7 @@ Each {{WorkletGlobalScope}} has an associated <a>environment settings object</a>
 Each {{WorkletGlobalScope}} has a <dfn>worklet global scope execution environment</dfn>. This
 execution environment may be parallel (i.e. it may be on a separate thread, process, or other
 equivalent construct), or it may live on the same thread or process as the {{Worklet}} object it
-belongs to. Which thread or process it lives on is decided by the user-agent.
+belongs to. Which thread or process it lives on is decided by the user agent.
 
 Note:
     The {{WorkletGlobalScope}} has a limited global scope when compared to a
@@ -169,12 +164,13 @@ Note:
 ### The event loop ### {#the-event-loop}
 
 Each {{WorkletGlobalScope}} object has a distinct <a>event loop</a>. This <a>event loop</a> has no
-associated <a>browsing context</a>. Only tasks associated with the author invoking
-{{Worklet/import()}} use the <a>event loop</a>, in addition to the <a>microtask queue</a> when the
-user-agent invokes callbacks. The <a>event loop</a> is created by the <a>create a
+associated <a>browsing context</a>. The <a>event loop</a> is created by the <a>create a
 WorkletGlobalScope</a> algorithm.
 
 The <a>event loop</a> is run on the <a>worklet global scope execution environment</a> defined above.
+
+It is expected that only tasks associated {{Worklet/import()}}, the user agent invoking author
+defined callbacks, and <a>microtasks</a> will use this <a>event loop</a>.
 
 Note:
     Even through the <a>event loop processing model</a> specifies that it loops continually,
@@ -184,7 +180,7 @@ Note:
 ### Creating a WorkletGlobalScope ### {#creating-a-workletglobalscope}
 
 When a user agent is to <dfn>create a WorkletGlobalScope</dfn>, given |workletGlobalScopeType|,
-|moduleResponsesMap|, and |outsideSettings| it <em>must</em> run the following steps:
+|moduleResponsesMap|, and |outsideSettings|, it <em>must</em> run the following steps:
 
     1. Create the <a>worklet global scope execution environment</a> and run the rest of these steps
         in that context.
@@ -207,10 +203,11 @@ When a user agent is to <dfn>create a WorkletGlobalScope</dfn>, given |workletGl
     5. For each |entry| in the given |moduleResponsesMap| (in insertion order), run the following
         substeps:
 
-        1. Let |resolvedModuleURL| be |entry|'s key.
+        1. Let |moduleURLRecord| be |entry|'s key.
 
-        2. Let |script| be the result of <a>fetch a worklet script</a> given |resolvedModuleURL|,
-            |moduleResponsesMap|, |outsideSettings|, and |insideSettings|.
+        2. Let |script| be the result of <a>fetch a worklet script</a> given |moduleURLRecord|,
+            |moduleResponsesMap|, |outsideSettings|, and |insideSettings| when
+            it asynchronously completes.
 
         3. <a>Run a module script</a> given |script|.
 
@@ -304,8 +301,8 @@ times contain the same set of script source text and have the same behaviour. Th
 additional {{WorkletGlobalScope}}s should be transparent to the author.
 
 <div class='note'>
-    Practically user-agents aren't expected to implement the following algorithm using a
-    thread-safe map. Instead when {{Worklet/import()}} is called user-agents can fetch the module
+    Practically user agents aren't expected to implement the following algorithm using a
+    thread-safe map. Instead when {{Worklet/import()}} is called user agents can fetch the module
     graph on the main thread, and send the fetched sources (the data contained in the <a>module
     responses map</a>) to each thread which has a {{WorkletGlobalScope}}.
 
@@ -319,11 +316,11 @@ the user agent <em>must</em> run the following steps:
 
     2. Let |worklet| be the current {{Worklet}}.
 
-    3. Let |resolvedModuleURL| be the result of <a>parsing</a> the |moduleURL| argument relative to
+    3. Let |moduleURLRecord| be the result of <a>parsing</a> the |moduleURL| argument relative to
         the <a>relevant settings object</a> of <b>this</b>.
 
-    4. If this fails, reject |promise| with a "<a>SyntaxError</a>" <a>DOMException</a> and abort
-        these steps.
+    4. If |moduleURLRecord| is failure, then reject promise with a "<a>SyntaxError</a>"
+        <a>DOMException</a> and return |promise|.
 
     5. Return |promise|, and then continue running this algorithm <a>in parallel</a>.
 
@@ -333,82 +330,78 @@ the user agent <em>must</em> run the following steps:
 
     8. Let |workletGlobalScopeType| be |worklet|'s <a>worklet global scope type</a>.
 
-    9. Ensure that there is at least one {{WorkletGlobalScope}} in the <a>worklet's
-        WorkletGlobalScopes</a>.
+    9. If the <a>worklet's WorkletGlobalScopes</a> is empty, run the following steps:
 
-        If not run the following substeps:
+        1. <a>Create a WorkletGlobalScope</a> given |workletGlobalScopeType|, |moduleResponsesMap|,
+            and |outsideSettings|.
 
-            1. <a>Create a WorkletGlobalScope</a> given |workletGlobalScopeType|,
-                |moduleResponsesMap|, and |outsideSettings|.
+        2. Add the {{WorkletGlobalScope}} to <a>worklet's WorkletGlobalScopes</a>.
 
-            2. Add the {{WorkletGlobalScope}} to <a>worklet's WorkletGlobalScopes</a>.
+        The user agent may also create additional {{WorkletGlobalScope}}s at this time.
 
-        The user-agent may also create additional {{WorkletGlobalScope}}s at this time.
-
-        Asynchronously wait for this step to complete before continuing.
+        Wait for this step to complete before continuing.
 
     10. Let |pendingTaskList| be a new <a>list</a>.
 
     11. For each |workletGlobalScope| in the <a>worklet's WorkletGlobalScopes</a>, run these
         substeps:
 
-        1. <a>Append</a> |workletGlobalScope| to |pendingTaskList|.
+        1. <a for=list>Append</a> |workletGlobalScope| to |pendingTaskList|.
 
         2. <a>Queue a task</a> on the |workletGlobalScope| to <a>fetch and invoke a worklet
-            script</a> given |workletGlobalScope|, |resolvedModuleURL|, |moduleResponsesMap|,
+            script</a> given |workletGlobalScope|, |moduleURLRecord|, |moduleResponsesMap|,
             |outsideSettings|, |pendingTaskList|, and |promise|.
 
     Note: The rejecting and resolving of the |promise| occurs within the <a>fetch and invoke a
         worklet script</a> algorithm.
 
-<br>
+<hr>
 
-When the user-agent is to <dfn>fetch and invoke a worklet script</dfn> given |workletGlobalScope|,
-|resolvedModuleURL|, |moduleResponsesMap|, |outsideSettings|, |pendingTaskList| and |promise| the
-user-agent <em>must</em> run the following steps:
+When the user agent is to <dfn>fetch and invoke a worklet script</dfn> given |workletGlobalScope|,
+|moduleURLRecord|, |moduleResponsesMap|, |outsideSettings|, |pendingTaskList|, and |promise|, the
+user agent <em>must</em> run the following steps:
 
-Note: This algorithm should be run within the <a>worklet global scope execution environment</a>.
+Note: This algorithm is to be run within the <a>worklet global scope execution environment</a>.
 
 1. Let |insideSettings| be the |workletGlobalScope|'s associated <a>environment settings object</a>.
 
-2. Let |script| by the result of <a>fetch a worklet script</a> given |resolvedModuleURL|,
-    |moduleResponsesMap|, |outsideSettings|, and |insideSettings|.
+2. Let |script| by the result of <a>fetch a worklet script</a> given |moduleURLRecord|,
+    |moduleResponsesMap|, |outsideSettings|, and |insideSettings| when it asynchronously completes.
 
-3. If |script| is <em>null</em> <a>queue a task</a> on |outsideSettings|'s <a>responsible event
-    loop</a> to run the following substeps:
+3. If |script| is <em>null</em>, then <a>queue a task</a> on |outsideSettings|'s <a>responsible
+    event loop</a> to run these steps:
 
-    1. <a>Remove</a> |workletGlobalScope| from |pendingTaskList|.
+    1. <a for=list>Remove</a> |workletGlobalScope| from |pendingTaskList|.
 
     2. Reject |promise| with an "<a>AbortError</a>" <a>DOMException</a>.
 
 4. <a>Run a module script</a> given |script|.
 
-5. <a>Queue a task</a> on |outsideSettings|'s <a>responsible event loop</a> to run the following
-    substeps:
+5. <a>Queue a task</a> on |outsideSettings|'s <a>responsible event loop</a> to run these steps:
 
-    1. <a>Remove</a> |workletGlobalScope| from |pendingTaskList|.
+    1. <a for=list>Remove</a> |workletGlobalScope| from |pendingTaskList|.
 
-    2. If |pendingTaskList| <a>is empty</a> then resolve |promise|.
+    2. If |pendingTaskList| <a for=list>is empty</a>, then resolve |promise|.
 
-<br>
+<hr>
 
-When the user-agent is to <dfn>fetch a worklet script</dfn> given |resolvedModuleURL|,
-|moduleResponsesMap|, |outsideSettings|, and |insideSettings| the user-agent <em>must</em>
+When the user agent is to <dfn>fetch a worklet script</dfn> given |moduleURLRecord|,
+|moduleResponsesMap|, |outsideSettings|, and |insideSettings|, the user agent <em>must</em>
 run the following steps:
 
-Note: This algorithm should be run within the <a>worklet global scope execution environment</a>.
+Note: This algorithm is to be run within the <a>worklet global scope execution environment</a>.
 
-1. <a>Fetch a module worker script graph</a> given |resolvedModuleURL|, |outsideSettings|, "script",
+1. <a>Fetch a module worker script graph</a> given |moduleURLRecord|, |outsideSettings|, "script",
     "omit", and |insideSettings|.
 
     To <a>perform the request</a> given |request|, perform the following steps:
 
         1. Let |cache| be the |moduleResponsesMap|.
 
-        2. Let |url| be |request|'s <a >url</a>.
+        2. Let |url| be |request|'s <a for=request>url</a>.
 
-        3. If |cache| contains an entry with key |url| whose value is "fetching", wait (<a>in
-            parallel</a>) until that entry's value changes, then proceed to the next step.
+        3. If |cache| contains an entry with key |url| whose value is "fetching", wait until that
+            entry's value changes, then proceed to the next step.
 
         4. If |cache| contains an entry with key |url|, asynchronously complete this algorithm with
             that entry's value, and abort these steps.
@@ -425,7 +418,7 @@ Note: This algorithm should be run within the <a>worklet global scope execution 
 2. Return the result of <a>fetch a module worker script graph</a> when it asynchronously completes.
 
 Note: Specifically, if a script fails to parse or fails to load over the network, it will reject the
-    promise. If the script throws an error while first evaluating the promise should resolve as a
+    promise. If the script throws an error while first evaluating the promise it will resolve as a
     classes may have been registered correctly.
 
 <div class=example>
@@ -441,8 +434,8 @@ Note: Specifically, if a script fails to parse or fails to load over the network
         await CSS.paintWorklet.import('script.js');
     </pre>
 
-    Behind the scenes the user-agent may load the <code class='lang-javascript'>script.js</code>
-    into 4 global scopes, in which case the debugging tools for the user-agent would print:
+    Behind the scenes the user agent may load the <code class='lang-javascript'>script.js</code>
+    into 4 global scopes, in which case the debugging tools for the user agent would print:
     <pre class='lang-javascript'>
         [paintWorklet#1] Hello from a WorkletGlobalScope!
         [paintWorklet#4] Hello from a WorkletGlobalScope!
@@ -450,7 +443,7 @@ Note: Specifically, if a script fails to parse or fails to load over the network
         [paintWorklet#3] Hello from a WorkletGlobalScope!
     </pre>
 
-    If the user-agent decided to kill and restart a {{WorkletGlobalScope}} number 3 in this example,
+    If the user agent decided to kill and restart a {{WorkletGlobalScope}} number 3 in this example,
     it would print <code class='lang-javascript'>[paintWorklet#3] Hello from a
     WorkletGlobalScope!</code> again in the debugging tools when this occurs.
 </div>


### PR DESCRIPTION
Instead of relying on "in parallel" this change makes all the thread
hopping explicit via. message passing and queue tasks on the appropriate
event loop.

 - Fixes #372, changes arguments to fetch a module script graph.

 - Fixes #370, running scripts in parallel. Now the script explicitly are
   run within a task queued on the worklet global scope's event loop.

 - Fixes #318, actually runs the event loop.

 - Fixes #230, treats "fetch a module worker script graph" as
   asynchronous.

 - Fixes #377, as now performs a thread hop to create the workletglobalscope.

 - Probably fixes #225 ? I think I'm grabbing the correct state at each
   thread hop.