### PR TITLE
[worklets] Fill in privacy and security sections of worklets.

### DIFF
--- a/worklets/Overview.bs
+++ b/worklets/Overview.bs
@@ -416,17 +416,12 @@ Worklets do not introduce any usable API surface to the web themselves, instead 
 specifications, e.g. [[css-paint-api-1]], [[webaudio]] will extend this specification to provide
 useful functionality.
 
-Worklets are allowed to be used outside <a>SecureContexts</a> as specifications which extend/use
-worklets may be allowed to used outside <a>SecureContexts</a>.
+Specifications which use worklets should decide if their worklet(s) should be allowed outside
+<a>SecureContexts</a>.
 
 Worklets load their module scripts in the same manner that workers load their module scripts. This
 fetches the top-level script by the <a>fetch a single module script</a> algorithm which sets the
 <a for=request>mode</a> to "<code>cors</code>".
-
-The behaviour of loading scripts can be restricted by using <a>child-src</a> [[CSP]] directive. Each
-specification which extends this specification <em>must</em> provide a <a
-for=request>destination</a> which is sent along with requests in the <a>Fetch a module worker script
-graph</a> algorithm.
 
 Issue(w3c/css-houdini-drafts#378): Provide hook for downstream specifications to provide their
     destination type.

--- a/worklets/Overview.bs
+++ b/worklets/Overview.bs
@@ -13,6 +13,7 @@ Editor: Ian Kilpatrick, ikilpatrick@chromium.org
 <pre class="anchors">
 urlPrefix: http://heycam.github.io/webidl/; type: dfn;
     text: AbortError
+    text: SecureContext
     text: SyntaxError
     urlPrefix: #idl-;
         text: DOMException
@@ -41,6 +42,7 @@ urlPrefix: https://html.spec.whatwg.org/multipage/webappapis.html; type: dfn;
     text: event loop
     text: event loop processing model
     text: fetch a module script tree
+    text: fetch a single module script
     text: global object
     text: https state
     text: incumbent settings object
@@ -410,7 +412,33 @@ loops and callbacks exceeding imposed time limits.
 Security Considerations {#security-considerations}
 ==================================================
 
-Issue(w3c/css-houdini-drafts#92): Need to decide if to allow worklets for unsecure context, etc.
+Worklets do not introduce any usable API surface to the web themselves, instead other
+specifications, e.g. [[css-paint-api-1]], [[webaudio]] will extend this specification to provide
+useful functionality.
+
+Worklets are allowed to be used outside <a>SecureContexts</a> as specifications which extend/use
+worklets may be allowed to used outside <a>SecureContexts</a>.
+
+Worklets load their module scripts in the same manner that workers load their module scripts. This
+fetches the top-level script by the <a>fetch a single module script</a> algorithm which sets the
+<a for=request>mode</a> to "<code>cors</code>".
+
+The behaviour of loading scripts can be restricted by using <a>child-src</a> [[CSP]] directive. Each
+specification which extends this specification <em>must</em> provide a <a
+for=request>destination</a> which is sent along with requests in the <a>Fetch a module worker script
+graph</a> algorithm.
+
+Issue(w3c/css-houdini-drafts#378): Provide hook for downstream specifications to provide their
+    destination type.
+
+The specifications which extend/use worklets may have additional security considerations.
+
+Privacy Considerations {#privacy-considerations}
+================================================
+
+There are no known privacy impacts for this feature by itself.
+
+The specifications which extend/use worklets may have privacy considerations.
 
 Examples {#examples}
 ====================


### PR DESCRIPTION
Fixes #92. (better late than never? ;)

Broadly speaking worklets should be allowed in non-secure contexts as
downstream specs may want to use them there.

CSP wise this should work the same as workers, using the "child-src"
directive. I've filed issue #378 to allow each downstream spec to use a
unique destination, e.g. "paintworklet", "audioworklet", etc.

The CSP spec should probably be extended to have a "worklet-src"
directive (as there is now a "worker-src" directive now?).