### PR TITLE
[worklets] Reworks "Code Idempotency" section.

### DIFF
--- a/worklets/Overview.bs
+++ b/worklets/Overview.bs
@@ -99,28 +99,29 @@ expected to be shared between separate scripts. This is similar to the <a>docume
 Code Idempotency {#code-idempotency}
 ------------------------------------
 
-<em>This section is not normative.</em>
+Some specifications which use worklets ([[css-paint-api-1]]), allow user agents to parallelize work
+over multiple threads, or to move work between threads as required.
 
-Multiple instances of {{WorkletGlobalScope}} can be created for each {{Worklet}} that they belong
-to. User agents may choose to do this in order to parallelize work over multiple threads, or to move
-work between threads as required.
-
-Additionally different user agents may invoke a method on a class in a different order to other user
-agents.
+In these specifications user agents might invoke methods on a class in a different order to other
+user agents.
 
 As a result of this, to prevent this compatibility risk between user agents, authors who register
-classes on the global scope should make their code idempotent. That is, a method or set of methods
-on a class should produce the same output given a particular input.
+classes on the global scope using these APIs, should make their code idempotent. That is, a method
+or set of methods on a class should produce the same output given a particular input.
 
-The following techniques should be used in order to encourage authors to write code in an idempotent
-way:
+The following techniques are used in order to encourage authors to write code in an idempotent way:
+
  - No reference to the global object, e.g. <a>self</a> on a {{DedicatedWorkerGlobalScope}}.
+
  - Code is loaded as a <a>module script</a> which resulting in the code being executed in <a>strict
      mode code</a> without a shared this. This prevents two different module scripts sharing
      state be referencing shared objects on the global scope.
- - User agents may choose to always have at least two {{WorkletGlobalScope}}s per {{Worklet}} and
-    randomly assign a method or set of methods on a class to a particular global scope.
- - User agents may create and destroy {{WorkletGlobalScope}}s at any time.
+
+ - These specifications must require user agents to always have at least two {{WorkletGlobalScope}}s
+     per {{Worklet}} and randomly assign a method or set of methods on a class to a particular
+     global scope. These specifications can provide an opt-out under memory constraints.
+
+ - User agents can create and destroy {{WorkletGlobalScope}}s at any time for these specifications.
 
 Infrastructure {#infrastructure}
 ================================
@@ -366,7 +367,11 @@ When the <dfn method for=Worklet>import(|moduleURL|, |options|)</dfn> method is 
 
         2. Add the {{WorkletGlobalScope}} to <a>worklet's WorkletGlobalScopes</a>.
 
-        The user agent may also create additional {{WorkletGlobalScope}}s at this time.
+        Depending on the type of worklet the user agent may create additional
+        {{WorkletGlobalScope}}s at this time.
+
+        Note: Specifically the [[css-paint-api-1]] allows for multiple global scopes, while the
+            [[webaudio]] API does not.
 
         Wait for this step to complete before continuing.
 


### PR DESCRIPTION
Fixes #384.

Fixes #308. (There is a separate issue for adding the 2
    WorkletGlobalScopes requirement for css-paint-api).