### PR TITLE
Add description for StylePropertyMapReadOnly.get()

### DIFF
--- a/css-typed-om/Overview.bs
+++ b/css-typed-om/Overview.bs
@@ -275,8 +275,19 @@ The <dfn method for=StylePropertyMap>append(DOMString <var>property</var>,
 <div algorithm>
     To <dfn>get a value from a StylePropertyMap</dfn>, run these steps:
 
-    Issue(148): Write this
+    1. If |property| does not start with two dashes (U+002D HYPHEN),
+        let |property| be |property| [=ASCII lowercased=].
 
+    2. If |property| is not a [=supported property name=],
+        [=throw=] a {{TypeError}} and exit this algorithm.
+
+    3. If |property| is not a [=list-valued property=],
+        [=throw=] a {{TypeError}} and exit this algorithm.
+
+    4. If {{StylePropertyMap}}’s [=property model=] contains an entry for |property|,
+        return that entry.
+    
+    5. Else, return `null`.
 </div>
 
 <div algorithm>

--- a/css-typed-om/Overview.bs
+++ b/css-typed-om/Overview.bs
@@ -282,7 +282,7 @@ The <dfn method for=StylePropertyMap>append(DOMString <var>property</var>,
         [=throw=] a {{TypeError}} and exit this algorithm.
 
     3. If {{StylePropertyMap}}’s [=property model=] contains an entry for |property|,
-        return that entry.
+        return the first value found in that entry.
     
     4. Else, return `null`.
 </div>

--- a/css-typed-om/Overview.bs
+++ b/css-typed-om/Overview.bs
@@ -281,13 +281,10 @@ The <dfn method for=StylePropertyMap>append(DOMString <var>property</var>,
     2. If |property| is not a [=supported property name=],
         [=throw=] a {{TypeError}} and exit this algorithm.
 
-    3. If |property| is not a [=list-valued property=],
-        [=throw=] a {{TypeError}} and exit this algorithm.
-
-    4. If {{StylePropertyMap}}’s [=property model=] contains an entry for |property|,
+    3. If {{StylePropertyMap}}’s [=property model=] contains an entry for |property|,
         return that entry.
     
-    5. Else, return `null`.
+    4. Else, return `null`.
 </div>
 
 <div algorithm>


### PR DESCRIPTION
@shans PTAL? This adds a description for get() which is one of the functions mentioned in #148. 

Will do the other functions in different CLs. 