### PR TITLE
Add description for StylePropertyMapReadOnly.has()

### DIFF
--- a/css-typed-om/Overview.bs
+++ b/css-typed-om/Overview.bs
@@ -280,6 +280,17 @@ The <dfn method for=StylePropertyMap>append(DOMString <var>property</var>,
 </div>
 
 <div algorithm>
+    To <dfn>check if StylePropertyMap has a property</dfn>, run these steps:
+
+    1. Run the algorithm to [=get a value from a StylePropertyMap=] with property <var>property</var>,
+        1. If the algoritm returns a {{CSSStyleValue}} return true.
+
+        2. If the algorithm returns `null` return false.
+
+</div>
+
+
+<div algorithm>
     To <dfn>set a value on a StylePropertyMap</dfn>, run these steps:
 
     Issue(148): Write this


### PR DESCRIPTION
@shans PTAL? This adds a description for has() which is one of the functions mentioned in #148.

Will do the other functions in different CLs.