### PR TITLE
Add description for StylePropertyMapReadOnly.set()

### DIFF
--- a/css-typed-om/Overview.bs
+++ b/css-typed-om/Overview.bs
@@ -282,7 +282,23 @@ The <dfn method for=StylePropertyMap>append(DOMString <var>property</var>,
 <div algorithm>
     To <dfn>set a value on a StylePropertyMap</dfn>, run these steps:
 
-    Issue(148): Write this
+    1. If |property| does not start with two dashes (U+002D HYPHEN),
+        let |property| be |property| [=ASCII lowercased=].
+
+    2. If |property| is not a [=supported property name=],
+        [=throw=] a {{TypeError}} and exit this algorithm.
+
+    3. If {{StylePropertyMap}}’s [=property model=] contains an entry for |property|,
+        let |entry| be that entry.
+        Otherwise, exit the algorithm.
+
+    4. Empty the list of |values| currently stored on the |entry|.
+
+    5. Let |values to set| be an empty list.
+
+    6. For each |value| in |values| if the [=algorithm that coerces value into an appropriate type for a given property=] does not throw an error, append the returned object to |values to set|.
+
+    7. Set |values to set| to be |entry|’s list.
 </div>
 
 The <dfn method for=StylePropertyMap>update(DOMString <var>property</var>,


### PR DESCRIPTION
This adds a description for StylePropertyMapReadOnly.set() which is mentioned in #148 

@shans  PTAL? Thanks!