### PR TITLE
Add devicePixelRatio property to PaintRenderingContext2D

### DIFF
--- a/css-paint-api/Overview.bs
+++ b/css-paint-api/Overview.bs
@@ -131,10 +131,10 @@ partial interface CSS {
 
 The {{PaintWorkletGlobalScope}} is the global execution context of the {{paintWorklet}}.
 
-The {{PaintWorkletGlobalScope}} has a devicePixelRatio property, which represents the ratio
-of the resolution in physical pixels to the resolution of CSS pixels for the current display
-device. When measured from the same display device, this value must be identical to the
-Window.devicePixelRatio.
+The {{PaintWorkletGlobalScope}} has a {{PaintWorkletGlobalScope/devicePixelRatio}} property,
+which represents the ratio of the resolution in physical pixels to the resolution of CSS
+pixels for the current display device. When measured from the same display device, this
+value must be identical to the Window.devicePixelRatio.
 
 <pre class='idl'>
 [Global=(Worklet,PaintWorklet),Exposed=PaintWorklet]

--- a/css-paint-api/Overview.bs
+++ b/css-paint-api/Overview.bs
@@ -131,10 +131,8 @@ partial interface CSS {
 
 The {{PaintWorkletGlobalScope}} is the global execution context of the {{paintWorklet}}.
 
-The {{PaintWorkletGlobalScope}} has a {{PaintWorkletGlobalScope/devicePixelRatio}} property,
-which represents the ratio of the resolution in physical pixels to the resolution of CSS
-pixels for the current display device. When measured from the same display device, this
-value must be identical to the Window.{{Window/devicePixelRatio}}.
+The {{PaintWorkletGlobalScope}} has a {{PaintWorkletGlobalScope/devicePixelRatio}}
+property which is identical to the Window.{{Window/devicePixelRatio}} property.
 
 <pre class='idl'>
 [Global=(Worklet,PaintWorklet),Exposed=PaintWorklet]

--- a/css-paint-api/Overview.bs
+++ b/css-paint-api/Overview.bs
@@ -356,6 +356,7 @@ The 2D rendering context {#2d-rendering-context}
 <pre class='idl'>
 [Exposed=PaintWorklet]
 interface PaintRenderingContext2D {
+    readonly attribute unrestricted double devicePixelRatio;
 };
 PaintRenderingContext2D implements CanvasState;
 PaintRenderingContext2D implements CanvasTransform;
@@ -382,6 +383,11 @@ The size of the <a>output bitmap</a> does not necessarily represent the size of 
 that the user agent will use internally or during rendering. For example, if the visual viewport is
 zoomed the user agent may internally use bitmaps which correspond to the number of device pixels in
 the coordinate space, so that the resulting rendering is of high quality.
+
+A {{PaintRenderingContext2D}} object has a devicePixelRatio property, which represents the ratio
+of the resolution in physical pixels to the resolution of CSS pixels for the current display
+device. When measured from the same display device, this value must be identical to the
+Window.devicePixelRatio.
 
 Additionally the user agent may record the sequence of drawing operations which have been applied to
 the <a>output bitmap</a> such that the user agent can subsequently draw onto a device bitmap at the

--- a/css-paint-api/Overview.bs
+++ b/css-paint-api/Overview.bs
@@ -134,7 +134,7 @@ The {{PaintWorkletGlobalScope}} is the global execution context of the {{paintWo
 The {{PaintWorkletGlobalScope}} has a {{PaintWorkletGlobalScope/devicePixelRatio}} property,
 which represents the ratio of the resolution in physical pixels to the resolution of CSS
 pixels for the current display device. When measured from the same display device, this
-value must be identical to the Window.devicePixelRatio.
+value must be identical to the Window.{{Window/devicePixelRatio}}.
 
 <pre class='idl'>
 [Global=(Worklet,PaintWorklet),Exposed=PaintWorklet]

--- a/css-paint-api/Overview.bs
+++ b/css-paint-api/Overview.bs
@@ -131,10 +131,16 @@ partial interface CSS {
 
 The {{PaintWorkletGlobalScope}} is the global execution context of the {{paintWorklet}}.
 
+The {{PaintWorkletGlobalScope}} has a devicePixelRatio property, which represents the ratio
+of the resolution in physical pixels to the resolution of CSS pixels for the current display
+device. When measured from the same display device, this value must be identical to the
+Window.devicePixelRatio.
+
 <pre class='idl'>
 [Global=(Worklet,PaintWorklet),Exposed=PaintWorklet]
 interface PaintWorkletGlobalScope : WorkletGlobalScope {
     void registerPaint(DOMString name, VoidFunction paintCtor);
+    readonly attribute unrestricted double devicePixelRatio;
 };
 </pre>
 
@@ -356,7 +362,6 @@ The 2D rendering context {#2d-rendering-context}
 <pre class='idl'>
 [Exposed=PaintWorklet]
 interface PaintRenderingContext2D {
-    readonly attribute unrestricted double devicePixelRatio;
 };
 PaintRenderingContext2D implements CanvasState;
 PaintRenderingContext2D implements CanvasTransform;
@@ -383,11 +388,6 @@ The size of the <a>output bitmap</a> does not necessarily represent the size of 
 that the user agent will use internally or during rendering. For example, if the visual viewport is
 zoomed the user agent may internally use bitmaps which correspond to the number of device pixels in
 the coordinate space, so that the resulting rendering is of high quality.
-
-A {{PaintRenderingContext2D}} object has a devicePixelRatio property, which represents the ratio
-of the resolution in physical pixels to the resolution of CSS pixels for the current display
-device. When measured from the same display device, this value must be identical to the
-Window.devicePixelRatio.
 
 Additionally the user agent may record the sequence of drawing operations which have been applied to
 the <a>output bitmap</a> such that the user agent can subsequently draw onto a device bitmap at the


### PR DESCRIPTION
Per discussion here: https://github.com/w3c/css-houdini-drafts/issues/436, CSS working group agreed to add a devicePixelRatio property to the PaintRenderingContext2D.

@bfgeek Please review.