### PR TITLE
[css-typed-om] Add serialization for 'opacity'

### DIFF
--- a/css-typed-om/Overview.bs
+++ b/css-typed-om/Overview.bs
@@ -2905,7 +2905,7 @@ depending on the property they came from:
 
 : 'opacity'
 ::
-    1. If the value of type <<number>>,
+    1. If the value is of type <<number>>,
         return the result of serializing the <<number>> value.
     2. Otherwise, return the result of serializing the <<percentage>> value.
 

--- a/css-typed-om/Overview.bs
+++ b/css-typed-om/Overview.bs
@@ -2903,6 +2903,11 @@ depending on the property they came from:
         return "currentcolor".
     2. Otherwise, return the result of serializing the <<color>> value.
 
+: 'opacity'
+::
+    1. If the value of type <<number>>,
+        return the result of serializing the <<number>> value.
+    2. Otherwise, return the result of serializing the <<percentage>> value.
 
 
 Security Considerations {#security-considerations}


### PR DESCRIPTION
Adds instructions to serialize the opacity property.

@shans PTAL?