### PR TITLE
[worklets] Add language for non-derminism in a note.

### DIFF
--- a/css-paint-api/Overview.bs
+++ b/css-paint-api/Overview.bs
@@ -553,6 +553,14 @@ following steps:
         in the <a>worklet's WorkletGlobalScopes</a> <a>list</a>, unless the user agent is under
         memory constraints.
 
+        <div class='note'>
+            User-agents have to attempt to introduce some non-determinism in the selection process
+            above. For example they could:
+                - Each frame select a random global scope from the list.
+                - After invocation(s) of <a>draw a paint image</a> randomly choose to switch to a
+                    different global scope.
+        </div>
+
         Note: This is to ensure that authors do not rely on being able to store state on the global
             object or non-regeneratable state on the class.
 


### PR DESCRIPTION
This adds a note that user-agents must introduce some non-determinism into the selection process for a paint worklet global scope.

This came up in blinks intent-to-ship thread:
https://groups.google.com/a/chromium.org/forum/#!topic/blink-dev/Jex3idOld48

Issue: #471 