### PR TITLE
Remove references to CSSNumericValue.from() in the spec

### DIFF
--- a/css-typed-om/Overview.bs
+++ b/css-typed-om/Overview.bs
@@ -2766,7 +2766,7 @@ For example:
 var length1 = CSSNumericValue.parse("42.0px");
 length1.toString(); // "42.0px"
 
-var length2 = CSS.px(42);
+var length2 = CSS.px(42.0);
 length2.toString(); // "42px";
 
 element.style.width = "42.0px";

--- a/css-typed-om/Overview.bs
+++ b/css-typed-om/Overview.bs
@@ -2763,10 +2763,10 @@ The way that a {{CSSStyleValue}} serializes is dependent on how the value was co
 For example:
 
 <pre class='lang-javascript'>
-var length1 = CSSNumericValue.from("42.0px");
+var length1 = CSSNumericValue.parse("42.0px");
 length1.toString(); // "42.0px"
 
-var length2 = CSSNumericValue.from(42.0, "px");
+var length2 = CSS.px(42);
 length2.toString(); // "42px";
 
 element.style.width = "42.0px";


### PR DESCRIPTION
git branching magic - couldn't seem to merge these two pull requests. (due to a change in the branch name)

Adding Tab's comments on the previous patch here:

"from wasn't turned into to; from was the more generic factory function. It was replaced by parse in the first instance, and the CSSUnitValue constructor in the second instance (or CSS.px())."

Closing the other PR