### PR TITLE
[css-properties-values-api] Bikeshed fix

### DIFF
--- a/css-properties-values-api/Overview.bs
+++ b/css-properties-values-api/Overview.bs
@@ -38,9 +38,7 @@ Repository: w3c/css-houdini-drafts
 spec:css-transforms-1; type:type; text:<transform-function>
 spec:cssom-1; type:interface; text:CSS
 spec:css-color-4; type:property; text:color
-spec:dom;
-	type:dfn; text:ascii case-insensitive
-	type:interface; text:Document
+spec:dom; type:interface; text:Document
 </pre>
 
 Introduction {#intro}


### PR DESCRIPTION
Remove the unwanted linking default for "ascii case-insensitive". It's in [Infra](https://infra.spec.whatwg.org/#ascii-case-insensitive) now, and Bikeshed can autolink to the dfn.