### PR TITLE
[PaintWorklet] Explicit state the PaintSize could be fractional

### DIFF
--- a/css-paint-api/Overview.bs
+++ b/css-paint-api/Overview.bs
@@ -421,7 +421,7 @@ is treated as opaque black.
 When the user agent is to <dfn>create a PaintRenderingContext2D object</dfn> for a given |width|,
 |height|, and |paintRenderingContext2DSettings|, it <em>must</em> run the following steps:
     1. Create a new {{PaintRenderingContext2D}}.
-    2. <a>Set bitmap dimensions</a> for the context's <a>output bitmap</a> to |width| and |height|.
+    2. <a>Set bitmap dimensions</a> for the context's <a>output bitmap</a> to the rounded values of |width| and |height|.
     3. Set the {{PaintRenderingContext2D}}'s <a>alpha</a> flag to |paintRenderingContext2DSettings.alpha|.
     4. Return the new {{PaintRenderingContext2D}}.
 


### PR DESCRIPTION
It was pointed out here: https://github.com/w3c/css-houdini-drafts/issues/479, that the spec says to "Set bitmap dimensions for the context’s output bitmap to width and height", which implies that the width and height are integers.

This pull request makes change to say rounded values of width and height, which makes it explicit.