### PR TITLE
[css-paint-api] Typo in registerProperty: inherit -> inherits

### DIFF
--- a/css-paint-api/Overview.bs
+++ b/css-paint-api/Overview.bs
@@ -750,7 +750,7 @@ Animations API.
       name: '--circle-color',
       syntax: '&lt;color>',
       initialValue: 'black',
-      inherit: false
+      inherits: false
     });
     CSS.paintWorklet.addModule('circle.js');
 &lt;/script>

--- a/css-paint-api/circle/index.html
+++ b/css-paint-api/circle/index.html
@@ -23,7 +23,7 @@
       name: '--circle-color',
       syntax: '<color>',
       initialValue: 'black',
-      inherit: false
+      inherits: false
     });
     (CSS.paintWorklet.addModule || paintWorkle.import)('circle.js');
 </script>


### PR DESCRIPTION
Fix a typo in example code to match [PropertyDescriptor definition](https://drafts.css-houdini.org/css-properties-values-api/#registering-custom-properties)