### PR TITLE
[css-typed-om] Change CSSMathNegate type to same as its argument.

### DIFF
--- a/css-typed-om/Overview.bs
+++ b/css-typed-om/Overview.bs
@@ -1699,8 +1699,10 @@ of all the "math" operations.
             of each of the [=list/items=] in its {{CSSMathProduct/values}} internal slot.
 
         : {{CSSMathNegate}}
+        :: The [=type=] is the same as the [=type=] of its {{CSSMathNegate/values}} internal slot.
+
         : {{CSSMathInvert}}
-        :: The [=type=] is the same as the [=type=] of its {{CSSMathNegate/value}} internal slot,
+        :: The [=type=] is the same as the [=type=] of its {{CSSMathInvert/value}} internal slot,
             but with all [=map/values=] negated.
     </dl>
 </div>


### PR DESCRIPTION
Issue #516 

@tabatkins PTAL, thanks.