### PR TITLE
CSSVariableReferenceValue.variable setter rejects invalid variable names

### DIFF
--- a/css-typed-om/Overview.bs
+++ b/css-typed-om/Overview.bs
@@ -499,6 +499,18 @@ The <dfn attribute for=CSSUnparsedValue>length</dfn> attribute indicates how man
 
 The <dfn for=CSSUnparsedValue>indexed getter</dfn> retrieves the string fragment or variable reference at the provided index.
 
+<div algorithm="CSSVariableReferenceValue.variable">
+    The <dfn attribute for=CSSVariableReferenceValue>variable</dfn> attribute
+    of a {{CSSVariableReferenceValue}} |this| must, on setting a
+    variable |variable|, perform the following steps:
+
+    1. If |variable| does not start with two dashes (U+002D HYPHEN), [=throw=] a
+        {{TypeError}}, and exit this algorithm.
+
+    2. Otherwise, set |this|’s {{CSSVariableReferenceValue/variable}} internal slot,
+        to |variable|.
+ </div>
+
 <!--
 ██    ██ ████████ ██    ██ ██      ██  ███████  ████████  ████████
 ██   ██  ██        ██  ██  ██  ██  ██ ██     ██ ██     ██ ██     ██

--- a/css-typed-om/Overview.bs
+++ b/css-typed-om/Overview.bs
@@ -504,8 +504,9 @@ The <dfn for=CSSUnparsedValue>indexed getter</dfn> retrieves the string fragment
     of a {{CSSVariableReferenceValue}} |this| must, on setting a
     variable |variable|, perform the following steps:
 
-    1. If |variable| does not start with two dashes (U+002D HYPHEN), [=throw=] a
-        {{TypeError}}, and exit this algorithm.
+    1. If |variable| is not a [=custom property name string=], 
+        [=throw=] a {{TypeError}},
+        and exit this algorithm.
 
     2. Otherwise, set |this|’s {{CSSVariableReferenceValue/variable}} internal slot,
         to |variable|.


### PR DESCRIPTION
Fixes #524 
@tabatkins PTAL?