### PR TITLE
rename CSS.q() to CSS.Q()

### DIFF
--- a/css-typed-om/Overview.bs
+++ b/css-typed-om/Overview.bs
@@ -1712,7 +1712,7 @@ partial namespace CSS {
     CSSUnitValue vmax(double value);
     CSSUnitValue cm(double value);
     CSSUnitValue mm(double value);
-    CSSUnitValue q(double value);
+    CSSUnitValue Q(double value);
     CSSUnitValue in(double value);
     CSSUnitValue pt(double value);
     CSSUnitValue pc(double value);


### PR DESCRIPTION
Fixes #504 

CSS.Hz and CSS.kHz already had the correct case.

@tabatkins PTAL?