### PR TITLE
[css-layout-api] Fix incorrect extension of <<display-inside>>

### DIFF
--- a/css-layout-api/Overview.bs
+++ b/css-layout-api/Overview.bs
@@ -104,10 +104,8 @@ computed style and <a>box tree</a> changes.
 Layout API Containers {#layout-api-containers}
 ==============================================
 
-<pre class="propdef">
-    Name: <<display-inside>>
-    New values: layout(<<ident>>)
-</pre>
+A new <a href="https://www.w3.org/TR/css-values-3/#comb-one">alternative</a> value is added
+to the <<display-inside>> production: <code>layout(<<ident>>)</code>.
 
 <dl dfn-for="display" dfn-type=value>
     <dt><dfn>layout()</dfn>


### PR DESCRIPTION
`<<display-inside>>` isn't a property, so you cannot use a propdef table
to extend it (and incidentally, that made bikeshed generate some
garbage).

Explicitly extend the `<<display-inside>>` production instead.

This commit does not change the intended meaning of the normative prose,
merely defines it more correctly, and should therefore be considered
editorial.