### PR TITLE
[css-typed-om] Restrict unsupported CSSStyleValues to the property that it was parsed with

### DIFF
--- a/css-typed-om/Overview.bs
+++ b/css-typed-om/Overview.bs
@@ -124,8 +124,10 @@ interface CSSStyleValue {
 </pre>
 
 {{CSSStyleValue}} objects are the base class of all CSS Values accessible via the Typed OM API.
+
 Values that can't yet be directly supported by a {{CSSStyleValue}} subclass
-are also represented as {{CSSStyleValue}} objects.
+are also represented as {{CSSStyleValue}} objects. These {{CSSStyleValue}} objects are only
+considered valid for the property that it was parsed with.
 
 The <a for="CSSStyleValue">stringification behavior</a> of {{CSSStyleValue}} objects is to
 return a normalized representation


### PR DESCRIPTION
Resolves #553 
@tabatkins PTAL, thanks!