### PR TITLE
CSSNumericValue.parse() allows {max,min,calc}()

### DIFF
--- a/css-typed-om/Overview.bs
+++ b/css-typed-om/Overview.bs
@@ -1234,7 +1234,7 @@ rather than on {{CSSNumericValue}} instances.
         and abort this algorithm.
 
     2. If |result| is not a <<number-token>>, <<percentage-token>>, <<dimension-token>>,
-        or [=math functions=],
+        or a [=math function=],
         [=throw=] a {{SyntaxError}}
         and abort this algorithm.
 

--- a/css-typed-om/Overview.bs
+++ b/css-typed-om/Overview.bs
@@ -1234,7 +1234,7 @@ rather than on {{CSSNumericValue}} instances.
         and abort this algorithm.
 
     2. If |result| is not a <<number-token>>, <<percentage-token>>, <<dimension-token>>,
-        or a <<calc()>>,
+        or [=math functions=],
         [=throw=] a {{SyntaxError}}
         and abort this algorithm.
 


### PR DESCRIPTION
Fixes #579