### PR TITLE
CSSStyleValue.parseAll should always return a list

### DIFF
--- a/css-typed-om/Overview.bs
+++ b/css-typed-om/Overview.bs
@@ -164,13 +164,13 @@ and parseMultiple set to true.
         Otherwise,
         let |value| be the parsed result.
 
-    4. If |property| is a [=list-valued property=], and |parseMultiple| is true,
+    4. If |parseMultiple| is true,
         subdivide |value| into a list of {{CSSStyleValue}} objects,
         each representing one [=list-valued property iteration=],
         and let |value| be the result. Return |value| as a sequence of
         {{CSSStyleValue}} objects.
 
-    5. If |property| is a [=list-valued property=], and |parseMultiple| is false
+    5. If |parseMultiple| is false
         subdivide |value| into a list of {{CSSStyleValue}} objects,
         each representing one [=list-valued property iteration=],
         and let |value| be the first entry in this list.


### PR DESCRIPTION
Fixes #502 