### PR TITLE
Sanitize the declared and inline StylePropertyMaps

### DIFF
--- a/css-typed-om/Overview.bs
+++ b/css-typed-om/Overview.bs
@@ -446,12 +446,12 @@ Declared {{StylePropertyMap}} objects {#declared-stylepropertymap-objects}
 
 <pre class='idl'>
 partial interface CSSStyleRule {
-    [SameObject] readonly attribute StylePropertyMap attributeStyleMap;
+    [SameObject] readonly attribute StylePropertyMap styleMap;
 };
 </pre>
 
 <dfn>Declared StylePropertyMap</dfn> objects represent style property-value pairs embedded
-in a style rule, and are accessed via the <dfn attribute for=CSSStyleRule>attributeStyleMap</dfn>
+in a style rule, and are accessed via the <dfn attribute for=CSSStyleRule>styleMap</dfn>
 attribute of {{CSSStyleRule}} objects.
 
 When constructed, the [=contained properties map=] for [=declared StylePropertyMap=]
@@ -465,14 +465,14 @@ Inline {{StylePropertyMap}} objects {#inline-stylepropertymap-objects}
 ----------------------------------------------------------------------
 
 <pre class='idl'>
-partial interface Element {
+partial interface ElementCSSInlineStyle {
     [SameObject] readonly attribute StylePropertyMap attributeStyleMap;
 };
 </pre>
 
 <dfn>Inline StylePropertyMap</dfn> objects represent inline style declarations attached
-directly to {{Element}}s. They are accessed via the <dfn attribute for=Element>attributeStyleMap</dfn>
-attribute of {{Element}} objects.
+directly to {{Element}}s. They are accessed via the <dfn attribute for=Element>styleMap</dfn>
+attribute of {{Element}} {{ElementCSSInlineStyle}} interface.
 
 When constructed, the [=contained properties map=] for [=inline StylePropertyMap=] objects
 is initialized to contain an

--- a/css-typed-om/Overview.bs
+++ b/css-typed-om/Overview.bs
@@ -470,9 +470,10 @@ partial interface ElementCSSInlineStyle {
 };
 </pre>
 
-<dfn>Inline StylePropertyMap</dfn> objects represent inline style declarations attached
-directly to {{Element}}s. They are accessed via the <dfn attribute for=Element>styleMap</dfn>
-attribute of {{Element}} {{ElementCSSInlineStyle}} interface.
+<dfn>Inline StylePropertyMap</dfn> objects represent inline style declarations 
+attached directly to {{Element}}s. 
+They are accessed via the <dfn attribute for=ElementCSSInlineStyle>attributeStyleMap</dfn> attribute of {{Element}} objects
+(via the {{ElementCSSInlineStyle}} mixin interface).
 
 When constructed, the [=contained properties map=] for [=inline StylePropertyMap=] objects
 is initialized to contain an


### PR DESCRIPTION
1. Replace CSSStyleRule.attributeStyleMap-> CSSStyleRule.styleMap
2. Clarify that the attribueStyleMap on Element is actually on ElementCSSInlineStyle interface

Fixes #572