### PR TITLE
Use indexed getters for CSSUnparsedValue

### DIFF
--- a/css-typed-om/Overview.bs
+++ b/css-typed-om/Overview.bs
@@ -549,8 +549,6 @@ interface CSSVariableReferenceValue {
 };
 </pre>
 
-Issue(239): Is this the best representation for this object?
-
 {{CSSUnparsedValue}} objects represent values that reference custom properties.
 They represent a list of string fragments and variable references.
 


### PR DESCRIPTION
Closes #239 , Looks like `CSSUnparsedValue` already uses indexed getters, so we can just remove the issue note from the spec?

Hi @tabatkins , PTAL