### PR TITLE
[css-typed-om] Add detail considering image state change and repaint.

### DIFF
--- a/css-typed-om/Overview.bs
+++ b/css-typed-om/Overview.bs
@@ -5048,7 +5048,7 @@ is set to ''loading''). If data is not required and the reference is valid then
 
 If {{CSSResourceValue/state}} is set to ''loading'' then the image
 reference is reevaluated once the pending data becomes available, according to the
-same rules referenced above.
+same rules referenced above. When the {{CSSResourceValue/state}} changes it'll automatically trigger a repaint.
 
 Reification can not fail for {{CSSResourceValue}} objects.
 


### PR DESCRIPTION
Added repaint related detail based on the discussion from [issue #741](https://github.com/w3c/css-houdini-drafts/issues/741). 