### PR TITLE
[worklets] Change the default credentials mode

### DIFF
--- a/worklets/Overview.bs
+++ b/worklets/Overview.bs
@@ -329,7 +329,7 @@ interface Worklet {
 };
 
 dictionary WorkletOptions {
-    RequestCredentials credentials = "omit";
+    RequestCredentials credentials = "same-origin";
 };
 </pre>
 


### PR DESCRIPTION
This changes the default credentials mode from 'omit' to 'same-origin'.

Issue: #756