### PR TITLE
[css-properties-values-api] Clarify computed value of <transform-function>

### DIFF
--- a/css-properties-values-api/Overview.bs
+++ b/css-properties-values-api/Overview.bs
@@ -424,7 +424,7 @@ computed value is as specified. Calc expressions that are
 &lt;number> and &lt;percentage> values get reduced during computation to simple
 numbers and percentages respectively.
 
-For &lt;transform-function> values contained in &lt;transform-list> values,
+For &lt;transform-function> values (including those contained in &lt;transform-list> values),
 the computed value is as specified but with all lengths resolved to their
 computed values.
 


### PR DESCRIPTION
The current text doesn't actually mention what should happen with
`<transform-function>` values that do NOT appear in `<transform-list>`.