### PR TITLE
[css-typed-om] Define reification of registered custom properties.

### DIFF
--- a/css-typed-om/Overview.bs
+++ b/css-typed-om/Overview.bs
@@ -2905,7 +2905,16 @@ regardless of what property it is for.
     and return the result.
 
 : registered [=custom properties=] [[css-properties-values-api-1]]
-:: Issue: Should be defined by the Props & Values spec
+::
+
+    : For specified values:
+    :: The value is treated as an unregistered property:
+        [=reify a list of component values=] from the value, and return the
+        result.
+
+    : For computed values:
+    :: The value is reified according to its type, as described in
+        the subsections of [[#reify-stylevalue]].
 
 : <a>align-content</a>
 ::

--- a/css-typed-om/Overview.bs
+++ b/css-typed-om/Overview.bs
@@ -2905,16 +2905,8 @@ regardless of what property it is for.
     and return the result.
 
 : registered [=custom properties=] [[css-properties-values-api-1]]
-::
-
-    : For specified values:
-    :: The value is treated as an unregistered property:
-        [=reify a list of component values=] from the value, and return the
-        result.
-
-    : For computed values:
-    :: The value is reified according to its type, as described in
-        the subsections of [[#reify-stylevalue]].
+:: For both specified and computed values, the value is reified according to its
+    type, as described in the subsections of [[#reify-stylevalue]].
 
 : <a>align-content</a>
 ::


### PR DESCRIPTION
I don't think we need to define the reification in detail in the
[css-properties-values-api] spec. CSS Typed OM § 5 already describes
how to reify all the types mentioned in [css-properties-values-api]. I.e.
the two specs are already adequately connected though the types.