### PR TITLE
[css-layout-api][css-paint-api][css-properties-values-api] Use partial namespace CSS

### DIFF
--- a/css-layout-api/Overview.bs
+++ b/css-layout-api/Overview.bs
@@ -1369,7 +1369,7 @@ which are related to layout.
 The {{layoutWorklet}}'s <a>worklet global scope type</a> is {{LayoutWorkletGlobalScope}}.
 
 <pre class='idl'>
-partial interface CSS {
+partial namespace CSS {
     [SameObject] readonly attribute Worklet layoutWorklet;
 };
 </pre>

--- a/css-paint-api/Overview.bs
+++ b/css-paint-api/Overview.bs
@@ -90,7 +90,7 @@ which are related to painting.
 The {{paintWorklet}}'s <a>worklet global scope type</a> is {{PaintWorkletGlobalScope}}.
 
 <pre class='idl'>
-partial interface CSS {
+partial namespace CSS {
     [SameObject] readonly attribute Worklet paintWorklet;
 };
 </pre>

--- a/css-properties-values-api/Overview.bs
+++ b/css-properties-values-api/Overview.bs
@@ -72,8 +72,8 @@ dictionary PropertyDescriptor {
 	         DOMString initialValue;
 };
 
-partial interface CSS {
-	static void registerProperty(PropertyDescriptor descriptor);
+partial namespace CSS {
+	void registerProperty(PropertyDescriptor descriptor);
 };
 </pre>
 


### PR DESCRIPTION
CSSOM and other CSS specs were updated in https://github.com/w3c/csswg-drafts/pull/437.

Fixes https://www.w3.org/Bugs/Public/show_bug.cgi?id=29623.