### PR TITLE
[css-layout-api] Make BreakToken#childBreakTokens a FrozenArray

### DIFF
--- a/css-layout-api/Overview.bs
+++ b/css-layout-api/Overview.bs
@@ -825,7 +825,7 @@ interface ChildBreakToken {
 
 [Exposed=LayoutWorklet]
 interface BreakToken {
-    readonly attribute sequence&lt;ChildBreakToken> childBreakTokens;
+    readonly attribute FrozenArray&lt;ChildBreakToken> childBreakTokens;
     readonly attribute any data;
 };
 


### PR DESCRIPTION
Fixes https://github.com/w3c/css-houdini-drafts/issues/758.