### PR TITLE
[box-tree-api] Change children attribute from sequence<T> to FrozenArray<T>

### DIFF
--- a/box-tree-api/Overview.bs
+++ b/box-tree-api/Overview.bs
@@ -79,7 +79,7 @@ interface DeadFragmentInformation {
 	readonly attribute double top;
 	readonly attribute double left;
 	readonly attribute boolean isOverflowed;
-	readonly attribute sequence&lt;DeadFragmentInformation>? children;
+	readonly attribute FrozenArray&lt;DeadFragmentInformation>? children;
 	readonly attribute DeadFragmentInformation? nextSibling;
 	readonly attribute DeadFragmentInformation? previousSibling;
 	readonly attribute DeadFragmentInformation? nextInBox;


### PR DESCRIPTION
Web IDL does not allow attributes to be of type sequence<T>.