### PR TITLE
[css-typed-om] Use `partial interface mixin ElementCSSInlineStyle`

### DIFF
--- a/css-typed-om/Overview.bs
+++ b/css-typed-om/Overview.bs
@@ -729,7 +729,7 @@ partial interface CSSStyleRule {
     [SameObject] readonly attribute StylePropertyMap styleMap;
 };
 
-partial interface ElementCSSInlineStyle {
+partial interface mixin ElementCSSInlineStyle {
     [SameObject] readonly attribute StylePropertyMap attributeStyleMap;
 };
 </pre>
@@ -738,8 +738,8 @@ partial interface ElementCSSInlineStyle {
 represent style property-value pairs embedded in a style rule or inline style,
 and are accessed via the <dfn attribute for=CSSStyleRule>styleMap</dfn> attribute of {{CSSStyleRule}} objects,
 or the <dfn attribute for="ElementCSSInlineStyle">attributeStyleMap</dfn> attribute
-of objects implementing the {{ElementCSSInlineStyle}} interface
-(such as {{Element}}s).
+of objects implementing the {{ElementCSSInlineStyle}} interface mixin
+(such as {{HTMLElement}}s).
 
 When constructed, the {{[[declarations]]}} internal slot for [=declared StylePropertyMap=] objects
 is initialized to contain an entry


### PR DESCRIPTION
https://drafts.csswg.org/cssom/#the-elementcssinlinestyle-interface is an
interface mixin, and the partial must match this. Update the prose to reflect
this as well.