### PR TITLE
[css-layout-api] Name the FragmentResultOptions argument

### DIFF
--- a/css-layout-api/Overview.bs
+++ b/css-layout-api/Overview.bs
@@ -1594,7 +1594,7 @@ dictionary FragmentResultOptions {
     BreakTokenOptions breakToken = null;
 };
 
-[Constructor(FragmentResultOptions)]
+[Constructor(optional FragmentResultOptions options)]
 interface FragmentResult {
     readonly attribute double inlineSize;
     readonly attribute double blockSize;


### PR DESCRIPTION
This was invalid Web IDL. Also make it optional since there are no required members.