### PR TITLE
[css-properties-values-api] "Consume a name" returns a string.

### DIFF
--- a/css-properties-values-api/Overview.bs
+++ b/css-properties-values-api/Overview.bs
@@ -634,7 +634,7 @@ Parsing the syntax string {#parsing-syntax}
 	::  If the stream [=starts with an identifier=],
 		<a>reconsume the current input code point</a> from |stream|
 		then [=consume a name=] from |stream|,
-		and set |component|’s |name| to the returned <<ident-token>>’s value.
+		and set |component|’s |name| to the returned value.
 		Otherwise return failure.
 
 	:   anything else


### PR DESCRIPTION
"Consume a name" doesn't return an `<ident-token>`. Also, it seems more
clean to avoid css-syntax's tokens if we can.