### PR TITLE
[css-properties-values-api] Require <custom-ident> as component name.

### DIFF
--- a/css-properties-values-api/Overview.bs
+++ b/css-properties-values-api/Overview.bs
@@ -640,11 +640,11 @@ Parsing the syntax string {#parsing-syntax}
 		and set |component|’s |name| to the returned value.
 		Otherwise return failure.
 
+		If |component|’s |name| does not match the <<custom-ident>> production,
+		return failure.
+
 	:   anything else
 	::  Return failure.
-
-	If |component|’s |name| does not match the <<custom-ident>> production,
-	return failure.
 
 	If |component|’s |name| is a [=pre-multiplied data type name=],
 	return |component|.

--- a/css-properties-values-api/Overview.bs
+++ b/css-properties-values-api/Overview.bs
@@ -643,6 +643,9 @@ Parsing the syntax string {#parsing-syntax}
 	:   anything else
 	::  Return failure.
 
+	If |component|’s |name| does not match the <<custom-ident>> production,
+	return failure.
+
 	If |component|’s |name| is a [=pre-multiplied data type name=],
 	return |component|.
 

--- a/css-properties-values-api/Overview.bs
+++ b/css-properties-values-api/Overview.bs
@@ -640,7 +640,7 @@ Parsing the syntax string {#parsing-syntax}
 		and set |component|’s |name| to the returned value.
 		Otherwise return failure.
 
-		If |component|’s |name| does not match the <<custom-ident>> production,
+		If |component|’s |name| does not [=CSS/parse=] as a <<custom-ident>>,
 		return failure.
 
 	:   anything else


### PR DESCRIPTION
Something like this was in the original syntax parsing PR, but it got
lost at some point.

Resolves #879.