### PR TITLE
[css-paint-api] Lean on "syntax definition" concept.

### DIFF
--- a/css-paint-api/Overview.bs
+++ b/css-paint-api/Overview.bs
@@ -142,7 +142,7 @@ by the paint function). It consists of:
     <code>DOMStrings</code>.
 
  - A <dfn for="document paint definition">input argument syntaxes</dfn> which is a [=list=] of
-    parsed [[css-properties-values-api-1#supported-syntax-strings]].
+    [=syntax descriptors=].
 
  - A <dfn for="document paint definition">PaintRenderingContext2DSettings object</dfn>.
 
@@ -204,9 +204,9 @@ called, the user agent <em>must</em> run the following steps:
 
     12. [=list/For each=] |item| in |inputArguments| perform the following substeps:
 
-        1. Let |parsedSyntax| be the result of parsing |item| according to the rules in
-            [[css-properties-values-api-1#supported-syntax-strings]]. If it fails to parse
-            [=throw=] a [=TypeError=] and abort all these steps.
+        1. Attempt to [=consume a syntax descriptor=] from |item|.
+            If failure was returned, [=throw=] a [=TypeError=] and abort all these steps.
+            Otherwise, let |parsedSyntax| be the returned [=syntax descriptor=].
 
         2. [=list/Append=] |parsedSyntax| to |inputArgumentSyntaxes|.
 

--- a/css-paint-api/Overview.bs
+++ b/css-paint-api/Overview.bs
@@ -142,7 +142,7 @@ by the paint function). It consists of:
     <code>DOMStrings</code>.
 
  - A <dfn for="document paint definition">input argument syntaxes</dfn> which is a [=list=] of
-    [=syntax descriptors=].
+    [=syntax definitions=].
 
  - A <dfn for="document paint definition">PaintRenderingContext2DSettings object</dfn>.
 
@@ -204,9 +204,9 @@ called, the user agent <em>must</em> run the following steps:
 
     12. [=list/For each=] |item| in |inputArguments| perform the following substeps:
 
-        1. Attempt to [=consume a syntax descriptor=] from |item|.
+        1. Attempt to [=consume a syntax definition=] from |item|.
             If failure was returned, [=throw=] a [=TypeError=] and abort all these steps.
-            Otherwise, let |parsedSyntax| be the returned [=syntax descriptor=].
+            Otherwise, let |parsedSyntax| be the returned [=syntax definition=].
 
         2. [=list/Append=] |parsedSyntax| to |inputArgumentSyntaxes|.
 

--- a/css-properties-values-api/Overview.bs
+++ b/css-properties-values-api/Overview.bs
@@ -564,7 +564,7 @@ Parsing the syntax string {#parsing-syntax}
 ::  A sequence of <a>code points</a> which is either a <a>data type name</a>,
 	or a sequence that can produce a <<custom-ident>>.
 
-:   <dfn>syntax definition</dfn>
+:   <dfn export>syntax definition</dfn>
 ::  An object consisting of a list of <a>syntax components</a>.
 
 :   <dfn>universal syntax definition</dfn>


### PR DESCRIPTION
The css-properties-values-api now describes in detail how to produce a
"syntax descriptor" from a string, so it's better to link to that rather
than linking to a section in the spec.