### PR TITLE
[css-properties-values-api] Generally ignore syntax in APIs.

### DIFF
--- a/css-properties-values-api/Overview.bs
+++ b/css-properties-values-api/Overview.bs
@@ -711,21 +711,10 @@ Conditional Rules {#conditional-rules}
 --------------------------------------
 
 <div class=note>
-	''@supports'' rules and the {{CSS/supports(conditionText)}} method
+	''@supports'' rules and the {{CSS/supports}} method
 	behave as specified in [[!css-variables]],
 	without distinguishing between registered and unregistered custom properties,
 	and paying no attention to registered properties' syntaxes.
-
-	{{CSS/supports(property, value)}},
-	as specified in [[css-conditional-1]],
-	<em>does</em> pay attention to the syntax of registered custom properties.
-
-	The general principle in use
-	is that anything which evaluates the validity of a CSS property value on its own
-	will pay attention to the syntax of registered custom properties,
-	but anything parsing any larger construct
-	(such as declarations, or entire stylesheets)
-	will ignore the syntax.
 </div>
 
 Relative URLs {#relative-urls}
@@ -820,57 +809,12 @@ string.
 CSSOM {#cssom}
 ==============
 
-{{CSSStyleDeclaration}} Behavior {#css-style-declaration-behavior}
-------------------------------------------------------------------
-
-The <a>set a CSS declaration</a> algorithm gains an additional constraint
-for registered custom properties:
-
-* The target declaration must have a value that matches the registered
-	[=syntax descriptor|syntax=] of the property.
-
-This means that once a property is registered, it is not possible to use
-{{setProperty()}} with a value that violates the registered syntax of the
-property.
-
-Note: Registering a property with a particular syntax
-does not invalidate already-specified values for the property
-(that is, they're not thrown out at parse-time,
-like invalid properties usually are),
-even if those would violate the registered syntax.
-The registration <em>does</em> prevent new invalid values from being set,
-and affects how the custom property calculates its [=computed value=].
-
-<div class='example'>
-	For example,
-	in the following code snippet,
-	the ''--x'' property is set to a value
-	that doesn't match the later-registered syntax:
-
-	<pre class="lang-javascript">
-		document.body.style.setProperty('--x', '10px');
-		CSS.registerProperty({
-			name: '--x',
-			syntax: '&lt;color>',
-			initialValue: 'white',
-			inherits: false
-		});
-
-		// This still outputs "10px", as existing values aren't
-		// re-evaluated after a syntax is registered.
-		console.log(document.body.style.getPropertyValue('--x'));
-
-		// This silently fails, like any other property would
-		// when one attempts to set it to an invalid value.
-		document.body.style.setProperty('--x', '20px');
-
-		// Because ''--x'' is still set to "10px", which isn't
-		// a valid <<color>>, it will be "<l>[=invalid at computed-value time=]</l>",
-		// falling back to the registered initial value of "white".
-		// 'background-color' will then receive that color and get
-		// set to "white".
-		document.body.style.backgroundColor = "var(--x)";
-	</pre>
+<div class=note>
+	The value specified for a registered custom property is not
+	interpreted until computed-value time. This means that only APIs that
+	retrieve computed values are affected. Other APIs must ignore the
+	{{[[registeredPropertySet]]}} slot of the associated {{Document}}, and
+	treat all custom properties as unregistered.
 </div>
 
 {{CSSStyleValue}} Reification {#css-style-value-reification}
@@ -880,14 +824,8 @@ and affects how the custom property calculates its [=computed value=].
 	To <dfn>reify a registered custom property value</dfn> given a property
 	|property| and [=syntax descriptor=] |syntax|, run these steps:
 
-	For specified values:
-
-		1. If the value is a <<declaration-value>>, and |syntax| is not the
-			[=universal syntax descriptor=], attempt to [=CSS/parse=]
-			the value according to |syntax|. If this succeeds, [=reify=]
-			the result as if it were a computed value, and return that result.
-		2. Otherwise, [=reify a list of component values=] from the value, and
-			return the result.
+	For specified values, [=reify a list of component values=] from the value,
+	and return the result.
 
 	For computed values:
 

--- a/css-properties-values-api/Overview.bs
+++ b/css-properties-values-api/Overview.bs
@@ -711,7 +711,7 @@ Conditional Rules {#conditional-rules}
 --------------------------------------
 
 <div class=note>
-	''@supports'' rules and the {{CSS/supports}} method
+	''@supports'' rules and the {{CSS/supports()}} method
 	behave as specified in [[!css-variables]],
 	without distinguishing between registered and unregistered custom properties,
 	and paying no attention to registered properties' syntaxes.


### PR DESCRIPTION
Resolves #902.