### PR TITLE
[worklets] Queue a task to reject addModule()

### DIFF
--- a/worklets/Overview.bs
+++ b/worklets/Overview.bs
@@ -449,14 +449,16 @@ When the user agent is to <dfn>fetch and invoke a worklet script</dfn> given |wo
 
             2. Reject |promise| with an "{{AbortError}}" {{DOMException}}.
 
-    4. If |script|'s <a>error to rethrow</a> is not null, then run these steps:
+    4. If |script|'s <a>error to rethrow</a> is not null, then <a>queue a task</a> on
+        |outsideSettings|'s <a>responsible event loop</a> given |script|'s <a>error to rethrow</a>
+        to run these steps:
 
         1. If |pendingTaskStruct|'s <a for="pending tasks struct">counter</a> is not <b>-1</b>, then
             run these steps:
 
             1. Set |pendingTaskStruct|'s <a for="pending tasks struct">counter</a> to <b>-1</b>.
 
-            2. Reject |promise| with |script|'s <a>error to rethrow</a>.
+            2. Reject |promise| with <a>error to rethrow</a>.
 
     5. <a>Run a module script</a> given |script|.
 


### PR DESCRIPTION
This is a follow-up patch for #958. A task to reject addModule() should
be queued with script's error to rethrow to run on the thread where
addModule() is called.

This fixes #509 