### PR TITLE
[css-typed-om] Add missing parentheses for union

### DIFF
--- a/css-typed-om/Overview.bs
+++ b/css-typed-om/Overview.bs
@@ -3004,7 +3004,7 @@ interface CSSLab : CSSColorValue {
 
 [Exposed=(Window, Worker, PaintWorklet, LayoutWorklet)]
 interface CSSColor : CSSColorValue {
-    constructor(sequence<DOMString or CSSNumberish> variant)
+    constructor(sequence<(DOMString or CSSNumberish)> variant)
     /* CSSColor(["foo", 0, 1, .5], ["bar", "yellow"], 1, fallbackColor) */
     /* or just make the alpha and fallback successive optional args? */
 };

--- a/css-typed-om/Overview.bs
+++ b/css-typed-om/Overview.bs
@@ -3004,7 +3004,7 @@ interface CSSLab : CSSColorValue {
 
 [Exposed=(Window, Worker, PaintWorklet, LayoutWorklet)]
 interface CSSColor : CSSColorValue {
-    constructor(sequence<(DOMString or CSSNumberish)> variant)
+    constructor(sequence<(DOMString or CSSNumberish)> variant);
     /* CSSColor(["foo", 0, 1, .5], ["bar", "yellow"], 1, fallbackColor) */
     /* or just make the alpha and fallback successive optional args? */
 };


### PR DESCRIPTION
This currently causes IDL parser failure.