### PR TITLE
Removed [Exposed] from dictionary/enum

### DIFF
--- a/css-layout-api/Overview.bs
+++ b/css-layout-api/Overview.bs
@@ -267,19 +267,16 @@ The section describes how a web developer uses {{registerLayout(name, layoutCtor
 layout.
 
 <pre class='idl'>
-[Exposed=LayoutWorklet]
 dictionary LayoutOptions {
   ChildDisplayType childDisplay = "block";
   LayoutSizingMode sizing = "block-like";
 };
 
-[Exposed=LayoutWorklet]
 enum ChildDisplayType {
     "block", // default - "blockifies" the child boxes.
     "normal",
 };
 
-[Exposed=LayoutWorklet]
 enum LayoutSizingMode {
     "block-like", // default - Sizing behaves like block containers.
     "manual", // Sizing is specified by the web developer.


### PR DESCRIPTION
Per Web IDL, no extended attributes are applicable to dictionaries/enumerations:
https://heycam.github.io/webidl/#idl-dictionaries
https://heycam.github.io/webidl/#idl-enums