### PR TITLE
[css-paint-api] Add CanvasFilters to paint worklets

### DIFF
--- a/css-paint-api/Overview.bs
+++ b/css-paint-api/Overview.bs
@@ -339,6 +339,7 @@ PaintRenderingContext2D includes CanvasDrawPath;
 PaintRenderingContext2D includes CanvasDrawImage;
 PaintRenderingContext2D includes CanvasPathDrawingStyles;
 PaintRenderingContext2D includes CanvasPath;
+PaintRenderingContext2D includes CanvasFilters;
 </pre>
 
 Note: The {{PaintRenderingContext2D}} implements a subset of the {{CanvasRenderingContext2D}} API.


### PR DESCRIPTION
This is already implemented by chromium (the only existent implementation of css-paint-api):

https://source.chromium.org/chromium/chromium/src/+/main:third_party/blink/renderer/modules/csspaint/paint_rendering_context_2d.idl;l=41?q=paint_rendering_context_2d.idl&sq=package:chromium&ct=os

I do not see a reason why it should _not_ be there, as all other features of CanvasRenderingContext2D are (except for fonts).