### PR TITLE
[CSS-Typed-OM] Change reifying as from 'a CSSStyleValue' to 'an identifier'

### DIFF
--- a/css-typed-om/Overview.bs
+++ b/css-typed-om/Overview.bs
@@ -5474,7 +5474,7 @@ CSS <<color>> values become either {{CSSColorValue}}s
 or generic {{CSSStyleValue}}s (otherwise).
 
 <div algorithm>
-    To <dfn>reify a color value</dfn> |val| for a property |prop|:
+    To <dfn>reify a color value</dfn> |val|:
 
     1. If |val| is a <<hex-color>>,
         an ''rgb()'' function,

--- a/css-typed-om/Overview.bs
+++ b/css-typed-om/Overview.bs
@@ -5554,7 +5554,7 @@ or generic {{CSSStyleValue}}s (otherwise).
         of its red, green, blue, and alpha components, respectively.
 
     9. If |val| is any other color keyword,
-        return the result of [=reifying as an identifier=] |val|.
+        return the result of [=reifying an identifier=] from |val|.
 </div>
 
 

--- a/css-typed-om/Overview.bs
+++ b/css-typed-om/Overview.bs
@@ -5553,8 +5553,8 @@ or generic {{CSSStyleValue}}s (otherwise).
         set to the [=reification=]
         of its red, green, blue, and alpha components, respectively.
 
-    8. If |val| is any other color keyword,
-        return the result of [=reifying as a CSSStyleValue=] |val| for |prop|.
+    9. If |val| is any other color keyword,
+        return the result of [=reifying as an identifier=] |val|.
 </div>
 
 


### PR DESCRIPTION
Step 2 of  parse()  [1] says "Reify a color value from  result ".

However, "Reify a color value" algorithm [2] needs a second parameter,

which is a property to be consumed by step 9 only.

Therefore, Change step 9 from 'CSSStyleValue' to 'an identifier'[3] for reifying.

And the reify a color value algorithm no more need |prop|.

Hence, Remove the |prop| parameter of 'reifying a color value'.

[1] https://drafts.css-houdini.org/css-typed-om-1/#dom-csscolorvalue-parse
[2] https://drafts.css-houdini.org/css-typed-om-1/#reify-a-color-value
[3] https://drafts.css-houdini.org/css-typed-om-1/#reify-an-identifier

Working Chromium CL: https://chromium-review.googlesource.com/c/chromium/src/+/3522201
csswg issue: https://github.com/w3c/csswg-drafts/issues/7174
cc. @xiaochengh 