### PR TITLE
[css-typed-om] use undefined union value for StylePropertyMapReadOnly.get()

### DIFF
--- a/css-typed-om/Overview.bs
+++ b/css-typed-om/Overview.bs
@@ -314,9 +314,7 @@ The {{StylePropertyMap}} {#the-stylepropertymap}
 [Exposed=(Window, Worker, PaintWorklet, LayoutWorklet)]
 interface StylePropertyMapReadOnly {
     iterable<USVString, sequence<CSSStyleValue>>;
-    any get(USVString property);
-    /* 'any' means (undefined or CSSStyleValue) here,
-       see https://github.com/heycam/webidl/issues/60 */
+    (undefined or CSSStyleValue) get(USVString property);
     sequence<CSSStyleValue> getAll(USVString property);
     boolean has(USVString property);
     readonly attribute unsigned long size;


### PR DESCRIPTION
https://github.com/whatwg/webidl/issues/60 has been fixed for a long time.