### PR TITLE
[css-properties-values-api] Specify <string> syntax component name

### DIFF
--- a/css-properties-values-api/Overview.bs
+++ b/css-properties-values-api/Overview.bs
@@ -236,6 +236,9 @@ and <code>"&lt;percentage>"</code> values:
 	(such as a [=math function=]),
 	the computed value is defined by that function.
 
+For <code>"&lt;string>"</code> values,
+the computed value is as specified.
+
 For <code>"&lt;color>"</code> values,
 the value is computed by [=resolving color values=].
 
@@ -943,6 +946,8 @@ corresponding types accepted by the resulting <a>syntax component</a>.
 :   "&lt;length-percentage>"
 ::  Any valid <<length>> or <<percentage>> value, any valid <<calc()>>
 	expression combining <<length>> and <<percentage>> components.
+:   "&lt;string>"
+::  Any valid <<string>> value
 :   "&lt;color>"
 ::  Any valid <<color>> value
 :   "&lt;image>"


### PR DESCRIPTION
Fixes #1103