### PR TITLE
[css-typed-om] Add missing font units to CSS numeric factory

### DIFF
--- a/css-typed-om/Overview.bs
+++ b/css-typed-om/Overview.bs
@@ -2283,12 +2283,17 @@ partial namespace CSS {
     CSSUnitValue percent(double value);
 
     // <length>
+    CSSUnitValue cap(double value);
+    CSSUnitValue ch(double value);
     CSSUnitValue em(double value);
     CSSUnitValue ex(double value);
-    CSSUnitValue ch(double value);
     CSSUnitValue ic(double value);
-    CSSUnitValue rem(double value);
     CSSUnitValue lh(double value);
+    CSSUnitValue rcap(double value);
+    CSSUnitValue rch(double value);
+    CSSUnitValue rem(double value);
+    CSSUnitValue rex(double value);
+    CSSUnitValue ric(double value);
     CSSUnitValue rlh(double value);
     CSSUnitValue vw(double value);
     CSSUnitValue vh(double value);


### PR DESCRIPTION
Add missing cap / rcap / rch / rex / ric units.

Fixes #1106.