### PR TITLE
[css-properties-values-api] Use the appropriate ref link for "parse"

### DIFF
--- a/css-properties-values-api/Overview.bs
+++ b/css-properties-values-api/Overview.bs
@@ -647,7 +647,7 @@ if the value of the '@property/syntax' descriptor is not the [=universal syntax 
 the following conditions must be met for the ''@property'' rule to be valid:
 
 	* The '@property/initial-value' descriptor must be present.
-	* The '@property/initial-value' descriptor's value must [=consume a syntax definition|parse successfully=]
+	* The '@property/initial-value' descriptor's value must [=parse=] successfully
 		according to the grammar specified by the [=syntax definition=].
 	* The '@property/initial-value' must be [=computationally independent=].
 


### PR DESCRIPTION
I do not think the value of `initial-value` should be parsed with *consume a syntax definition*, but with *parse something according to a CSS grammar (aka simply parse)*.