### PR TITLE
[css-typed-om] Simplify CSSMathValues when creating internal rep.

### DIFF
--- a/css-typed-om/Overview.bs
+++ b/css-typed-om/Overview.bs
@@ -627,6 +627,9 @@ probably in an appendix.
         replace that value with the result of wrapping it in a fresh {{CSSMathSum}}
         whose {{CSSMathSum/values}} internal slot contains only that part of |value|.
 
+        If |value| is a {{CSSMathValue}},
+        replace it with the corresponding [=simplify a calculation tree|simplified=] value.
+
         Return the |value|.
 
     : If |value| is a {{USVString}},


### PR DESCRIPTION
[#9451](https://github.com/w3c/csswg-drafts/issues/9451)