### PR TITLE
 [css-typed-om] Renamed 'flex' base type to 'fraction'

### DIFF
--- a/css-typed-om/Overview.bs
+++ b/css-typed-om/Overview.bs
@@ -1025,7 +1025,7 @@ are represented by subclasses of the {{CSSNumericValue}} interface.
         "time",
         "frequency",
         "resolution",
-        "flex",
+        "fraction",
         "percent",
     };
 
@@ -1035,7 +1035,7 @@ are represented by subclasses of the {{CSSNumericValue}} interface.
         long time;
         long frequency;
         long resolution;
-        long flex;
+        long fraction;
         long percent;
         CSSNumericBaseType percentHint;
     };
@@ -1733,7 +1733,7 @@ The <dfn export for=CSSNumericValue lt="base type">base types</dfn> are
 "time",
 "frequency",
 "resolution",
-"flex",
+"fraction",
 and "percent".
 The ordering of a [=type=]’s entries always matches this [=base type=] ordering.
 The <dfn export for=CSSNumericValue>percent hint</dfn>
@@ -1762,8 +1762,8 @@ and to the CSS [=math functions=].
         :: Return «[ "frequency" → 1 ]»
         : |unit| is a <<resolution>> unit
         :: Return «[ "resolution" → 1 ]»
-        : |unit| is a <<flex>> unit
-        :: Return «[ "flex" → 1 ]»
+        : |unit| is a <<fraction>> unit
+        :: Return «[ "fraction" → 1 ]»
         : anything else
         :: Return failure.
     </dl>
@@ -1901,7 +1901,7 @@ A [=type=] is said to <dfn export for=CSSNumericValue>match</dfn> a CSS producti
 * A [=type=] matches <<length>>
     if its only non-zero [=map/entry=] is «[ "length" → 1 ]»
     and its [=percent hint=] is null.
-    Similarly for <<angle>>, <<time>>, <<frequency>>, <<resolution>>, and <<flex>>.
+    Similarly for <<angle>>, <<time>>, <<frequency>>, <<resolution>>, and <<fraction>>.
 * A [=type=] matches <<percentage>>
     if its only non-zero [=map/entry=] is «[ "percent" → 1 ]».
 * A [=type=] matches <<length-percentage>>
@@ -2352,7 +2352,7 @@ partial namespace CSS {
     CSSUnitValue dpcm(double value);
     CSSUnitValue dppx(double value);
 
-    // <flex>
+    // <fraction>
     CSSUnitValue fr(double value);
 };
 </xmp>


### PR DESCRIPTION
The `<flex>` data type got generalized and moved to CSS Values 5 and renamed to `<fraction>` in https://github.com/w3c/csswg-drafts/pull/9516.

So this adjustment also needs to be done in CSS Typed OM.
(Note that the type was renamed to 'fraction' to better distinguish it from Flexbox, because of the unit being called `fr`, and due to it getting more use cases outside of flexible grid track widths.)

Sebastian