### PR TITLE
[css-properties-values-api] Fix typo in URL example

### DIFF
--- a/css-properties-values-api/Overview.bs
+++ b/css-properties-values-api/Overview.bs
@@ -277,7 +277,7 @@ the computed value is one of the following:
 		<pre class='lang-html'>
 		&lt;link href="/style/foo/foo.css" rel="stylesheet" type="text/css">
 		&lt;link href="/style/bar/bar.css" rel="stylesheet" type="text/css">
-		&lt;div style="background-image: var(--url-foo), var(---url-bar);">
+		&lt;div style="background-image: var(--url-foo), var(--url-bar);">
 		&lt;/div>
 		</pre>
 


### PR DESCRIPTION
The "URL behavior examples" contained a typo where the used variable in the `<div>`'s `style` attribute had 3 dashes (`-`) instead of 2.