### PR TITLE
[css-properties-values-api-1][editorial] Match an empty string for initialValue

### DIFF
--- a/css-properties-values-api/Overview.bs
+++ b/css-properties-values-api/Overview.bs
@@ -740,7 +740,7 @@ as arguments of the same names.
 
 		Otherwise,
 		if |syntax definition| is the <a>universal syntax definition</a>,
-		[=CSS/parse=] |initialValue| as a <<declaration-value>>.
+		[=CSS/parse=] |initialValue| according to <code><<declaration-value>>?</code>.
 		If this fails,
 		<a>throw</a> a {{SyntaxError}}
 		and exit this algorithm.


### PR DESCRIPTION
There is no corresponding test on [WPT](https://github.com/web-platform-tests/wpt/blob/master/css/css-properties-values-api/register-property-syntax-parsing.html) but empty string is a valid [`initial-value`](https://drafts.css-houdini.org/css-properties-values-api-1/#initial-value-descriptor), and `CSS.registerProperty({ ..., syntax: '*', initialValue: '' })` works on current version of Chrome and FF.