### PR TITLE
[css-properties-values-api] Allow dashed idents in syntax strings

### DIFF
--- a/css-properties-values-api/Overview.bs
+++ b/css-properties-values-api/Overview.bs
@@ -1117,6 +1117,7 @@ Parsing The Syntax String {#parsing-syntax}
 		Otherwise, return failure.
 
 	:   <a>ident-start code point</a>
+	:   U+002D HYPHEN-MINUS
 	:   U+005C REVERSE SOLIDUS (\)
 	::  If the stream [=starts with an ident sequence=],
 		<a>reconsume the current input code point</a> from |stream|


### PR DESCRIPTION
Currently, grammars like `syntax:"auto | --mything"` are not allowed, since we don't handle HYPHEN-MINUS during "consume a syntax component". This was likely an oversight when it was initially written.

Note: we might want to just remove the algorithms that parse syntax components from a string, and instead tokenize/parse using the new `<syntax>` production. If we do, that would *also* make dashed idents allowed unless we explicitly block it.