### PR TITLE
Make PaintRenderingContext implement CanvasFilters

### DIFF
--- a/css-paint-api/Overview.bs
+++ b/css-paint-api/Overview.bs
@@ -334,6 +334,7 @@ PaintRenderingContext2D includes CanvasCompositing;
 PaintRenderingContext2D includes CanvasImageSmoothing;
 PaintRenderingContext2D includes CanvasFillStrokeStyles;
 PaintRenderingContext2D includes CanvasShadowStyles;
+PaintRenderingContext2D includes CanvasFilters;
 PaintRenderingContext2D includes CanvasRect;
 PaintRenderingContext2D includes CanvasDrawPath;
 PaintRenderingContext2D includes CanvasDrawImage;


### PR DESCRIPTION
This looks like an oversight, both implementations already do include that, and the below text doesn't mention it in the list of features that aren't included.

[Tests already exist](https://github.com/web-platform-tests/wpt/blob/master/css/css-paint-api/paint2d-filter.https.html).

I hope this doesn't qualify as a substantive change.