### PR TITLE
[css-typed-om] Use undefined for setters.

### DIFF
--- a/css-typed-om/Overview.bs
+++ b/css-typed-om/Overview.bs
@@ -838,7 +838,7 @@ interface CSSUnparsedValue : CSSStyleValue {
     iterable<CSSUnparsedSegment>;
     readonly attribute unsigned long length;
     getter CSSUnparsedSegment (unsigned long index);
-    setter CSSUnparsedSegment (unsigned long index, CSSUnparsedSegment val);
+    setter undefined (unsigned long index, CSSUnparsedSegment val);
 };
 
 typedef (USVString or CSSVariableReferenceValue) CSSUnparsedSegment;
@@ -2524,7 +2524,7 @@ interface CSSTransformValue : CSSStyleValue {
     iterable<CSSTransformComponent>;
     readonly attribute unsigned long length;
     getter CSSTransformComponent (unsigned long index);
-    setter CSSTransformComponent (unsigned long index, CSSTransformComponent val);
+    setter undefined (unsigned long index, CSSTransformComponent val);
 
     readonly attribute boolean is2D;
     DOMMatrix toMatrix();


### PR DESCRIPTION
Fixes #1142
See also https://github.com/whatwg/webidl/issues/1516