### PR TITLE
[css-properties-values-api][editorial] CSS.registerProperty() requires inherits argument

### DIFF
--- a/css-properties-values-api/Overview.bs
+++ b/css-properties-values-api/Overview.bs
@@ -694,9 +694,9 @@ as arguments of the same names.
 <div algorithm>
 	To <dfn>register a custom property</dfn>
 	with |name| being a string,
+	|inherits| being a boolean,
 	and optionally
 	|syntax| being a string,
-	|inherits| being a boolean,
 	and |initialValue| being a string,
 	execute these steps:
 


### PR DESCRIPTION
The [register a custom property algorithm](https://drafts.css-houdini.org/css-properties-values-api-1/#register-a-custom-property) is defined as taking `inherits` as an optional argument whereas it is passed from the [`PropertyDefinition`](https://drafts.css-houdini.org/css-properties-values-api-1/#dictdef-propertydefinition) dictionary, which defines it as `required`.

  > To register a custom property with `name` being a string, and optionally `syntax` being a string, `inherits` being a boolean, and `initialValue` being a string, ...

  > ```
  > dictionary PropertyDefinition {
  >   required DOMString name; 
  >   DOMString syntax       = "*"; 
  >   required boolean   inherits; 
  >   DOMString initialValue; 
  > };
  > ```