### PR TITLE
Update all api.csswg.org/bikeshed URLs to reference spec-generator

### DIFF
--- a/box-tree-api/Makefile
+++ b/box-tree-api/Makefile
@@ -7,13 +7,13 @@
 SOURCEFILE=Overview.bs
 OUTPUTFILE=Overview.html
 PREPROCESSOR=bikeshed.py
-REMOTE_PREPROCESSOR_URL=https://api.csswg.org/bikeshed/
+REMOTE_PREPROCESSOR_URL=https://www.w3.org/publications/spec-generator/
 
 all: $(OUTPUTFILE)
 
 $(OUTPUTFILE): $(SOURCEFILE)
 ifneq (,$(REMOTE))
-	curl $(REMOTE_PREPROCESSOR_URL) -F file=@$(SOURCEFILE) > "$@"
+	curl $(REMOTE_PREPROCESSOR_URL) -F file=@$(SOURCEFILE) -F type=bikeshed-spec > "$@"
 else
 	$(PREPROCESSOR) -f spec "$<" "$@"
 endif

--- a/css-animation-worklet-1/Makefile
+++ b/css-animation-worklet-1/Makefile
@@ -7,13 +7,13 @@
 SOURCEFILE=Overview.bs
 OUTPUTFILE=Overview.html
 PREPROCESSOR=bikeshed
-REMOTE_PREPROCESSOR_URL=https://api.csswg.org/bikeshed/
+REMOTE_PREPROCESSOR_URL=https://www.w3.org/publications/spec-generator/
 
 all: $(OUTPUTFILE)
 
 $(OUTPUTFILE): $(SOURCEFILE)
 ifneq (,$(REMOTE))
-	curl $(REMOTE_PREPROCESSOR_URL) -F file=@$(SOURCEFILE) > "$@"
+	curl $(REMOTE_PREPROCESSOR_URL) -F file=@$(SOURCEFILE) -F type=bikeshed-spec > "$@"
 else
 	$(PREPROCESSOR) -f spec "$<" "$@"
 endif

--- a/css-layout-api/Makefile
+++ b/css-layout-api/Makefile
@@ -7,13 +7,13 @@
 SOURCEFILE=Overview.bs
 OUTPUTFILE=Overview.html
 PREPROCESSOR=bikeshed.py
-REMOTE_PREPROCESSOR_URL=https://api.csswg.org/bikeshed/
+REMOTE_PREPROCESSOR_URL=https://www.w3.org/publications/spec-generator/
 
 all: $(OUTPUTFILE)
 
 $(OUTPUTFILE): $(SOURCEFILE)
 ifneq (,$(REMOTE))
-	curl $(REMOTE_PREPROCESSOR_URL) -F file=@$(SOURCEFILE) > "$@"
+	curl $(REMOTE_PREPROCESSOR_URL) -F file=@$(SOURCEFILE) -F type=bikeshed-spec > "$@"
 else
 	$(PREPROCESSOR) -f spec "$<" "$@"
 endif

--- a/css-paint-api/Makefile
+++ b/css-paint-api/Makefile
@@ -7,13 +7,13 @@
 SOURCEFILE=Overview.bs
 OUTPUTFILE=Overview.html
 PREPROCESSOR=bikeshed.py
-REMOTE_PREPROCESSOR_URL=https://api.csswg.org/bikeshed/
+REMOTE_PREPROCESSOR_URL=https://www.w3.org/publications/spec-generator/
 
 all: $(OUTPUTFILE)
 
 $(OUTPUTFILE): $(SOURCEFILE)
 ifneq (,$(REMOTE))
-	curl $(REMOTE_PREPROCESSOR_URL) -F file=@$(SOURCEFILE) > "$@"
+	curl $(REMOTE_PREPROCESSOR_URL) -F file=@$(SOURCEFILE) -F type=bikeshed-spec > "$@"
 else
 	$(PREPROCESSOR) -f spec "$<" "$@"
 endif

--- a/css-parser-api/Makefile
+++ b/css-parser-api/Makefile
@@ -7,13 +7,13 @@
 SOURCEFILE=Overview.bs
 OUTPUTFILE=Overview.html
 PREPROCESSOR=bikeshed.py
-REMOTE_PREPROCESSOR_URL=https://api.csswg.org/bikeshed/
+REMOTE_PREPROCESSOR_URL=https://www.w3.org/publications/spec-generator/
 
 all: $(OUTPUTFILE)
 
 $(OUTPUTFILE): $(SOURCEFILE)
 ifneq (,$(REMOTE))
-	curl $(REMOTE_PREPROCESSOR_URL) -F file=@$(SOURCEFILE) > "$@"
+	curl $(REMOTE_PREPROCESSOR_URL) -F file=@$(SOURCEFILE) -F type=bikeshed-spec > "$@"
 else
 	$(PREPROCESSOR) -f spec "$<" "$@"
 endif

--- a/css-properties-values-api/Makefile
+++ b/css-properties-values-api/Makefile
@@ -7,13 +7,13 @@
 SOURCEFILE=Overview.bs
 OUTPUTFILE=Overview.html
 PREPROCESSOR=bikeshed
-REMOTE_PREPROCESSOR_URL=https://api.csswg.org/bikeshed/
+REMOTE_PREPROCESSOR_URL=https://www.w3.org/publications/spec-generator/
 
 all: $(OUTPUTFILE)
 
 $(OUTPUTFILE): $(SOURCEFILE)
 ifneq (,$(REMOTE))
-	curl $(REMOTE_PREPROCESSOR_URL) -F file=@$(SOURCEFILE) > "$@"
+	curl $(REMOTE_PREPROCESSOR_URL) -F file=@$(SOURCEFILE) -F type=bikeshed-spec > "$@"
 else
 	$(PREPROCESSOR) -f spec "$<" "$@"
 endif

--- a/font-metrics-api/Makefile
+++ b/font-metrics-api/Makefile
@@ -7,13 +7,13 @@
 SOURCEFILE=Overview.bs
 OUTPUTFILE=Overview.html
 PREPROCESSOR=bikeshed.py
-REMOTE_PREPROCESSOR_URL=https://api.csswg.org/bikeshed/
+REMOTE_PREPROCESSOR_URL=https://www.w3.org/publications/spec-generator/
 
 all: $(OUTPUTFILE)
 
 $(OUTPUTFILE): $(SOURCEFILE)
 ifneq (,$(REMOTE))
-	curl $(REMOTE_PREPROCESSOR_URL) -F file=@$(SOURCEFILE) > "$@"
+	curl $(REMOTE_PREPROCESSOR_URL) -F file=@$(SOURCEFILE) -F type=bikeshed-spec > "$@"
 else
 	$(PREPROCESSOR) -f spec "$<" "$@"
 endif

--- a/worklets/Makefile
+++ b/worklets/Makefile
@@ -7,13 +7,13 @@
 SOURCEFILE=Overview.bs
 OUTPUTFILE=Overview.html
 PREPROCESSOR=bikeshed.py
-REMOTE_PREPROCESSOR_URL=https://api.csswg.org/bikeshed/
+REMOTE_PREPROCESSOR_URL=https://www.w3.org/publications/spec-generator/
 
 all: $(OUTPUTFILE)
 
 $(OUTPUTFILE): $(SOURCEFILE)
 ifneq (,$(REMOTE))
-	curl $(REMOTE_PREPROCESSOR_URL) -F file=@$(SOURCEFILE) > "$@"
+	curl $(REMOTE_PREPROCESSOR_URL) -F file=@$(SOURCEFILE) -F type=bikeshed-spec > "$@"
 else
 	$(PREPROCESSOR) -f spec "$<" "$@"
 endif


### PR DESCRIPTION
This updates Makefiles to use spec-generator, since the CSSWG bikeshed service is no longer available.

I'm not sure how actively-used `make REMOTE=1` is (as a couple of newer specs don't seem to follow this pattern at all), but I tested the output of each to make sure it still worked and largely matches the current EDs.